### PR TITLE
ci(publish): bump actions off deprecated Node 20 runtimes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # hatch-vcs needs full history + tags to derive the version
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade build
@@ -30,7 +30,7 @@ jobs:
           if ! ls dist/ | grep -q "smartthings_local-${version}"; then
             echo "Built artifacts do not match tag version ${version}"; exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -43,7 +43,7 @@ jobs:
     permissions:
       id-token: write  # required for Trusted Publishing (OIDC)
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
The publish workflow used action versions that run on the Node 20 runtime, which GitHub is deprecating. On the v0.1.2 release run the runner auto-forced them to Node 24 with a warning. This pins each to its current major so they run natively on Node 24 and drop the warning:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |

`upload-artifact@v7` / `download-artifact@v8` are the matching current majors and interoperate. No behavioral change to the build/publish steps; the workflow still triggers on `v*` tags and publishes via Trusted Publishing. Nothing runs until the next tag, so this is safe to merge whenever.