### PR TITLE
fix(setup-cert): keep SHA-1 retry compatible with LibreSSL

### DIFF
--- a/setup_cert.py
+++ b/setup_cert.py
@@ -216,6 +216,17 @@ def run(cmd, **kw):
 def run_allow_sha1(cmd):
     """Run an openssl command with SHA-1 signatures force-enabled, for
     distros whose crypto policy otherwise blocks SHA-1 signing."""
+    version = run(['openssl', 'version']).stdout.strip()
+    if not version.startswith('OpenSSL 3.'):
+        # The provider configuration below is specific to OpenSSL 3.
+        # LibreSSL can exit successfully without running the requested
+        # command when it is given that configuration, leaving no output
+        # certificate behind. Older OpenSSL releases do not need the
+        # provider override either, so retry them with a clean environment.
+        env = dict(os.environ)
+        env.pop('OPENSSL_CONF', None)
+        return run(cmd, env=env)
+
     conf = tempfile.NamedTemporaryFile(
         'w', suffix='.cnf', prefix='sha1_ok_', delete=False)
     conf.write(SHA1_OVERRIDE_CONF)

--- a/tests/test_setup_cert_signing.py
+++ b/tests/test_setup_cert_signing.py
@@ -77,6 +77,24 @@ def test_mint_cert_retries_when_sha1_signing_blocked(tmp_path, monkeypatch):
     assert paths["leaf"].exists()        # the override retry recovered
 
 
+def test_sha1_retry_does_not_give_openssl_3_config_to_libressl(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append((cmd, kw))
+        if cmd == ["openssl", "version"]:
+            return subprocess.CompletedProcess(cmd, 0, "LibreSSL 3.3.6\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(setup_cert, "run", fake_run)
+    monkeypatch.setenv("OPENSSL_CONF", "/synthetic/inherited.cnf")
+
+    setup_cert.run_allow_sha1(["openssl", "x509", "-req"])
+
+    assert calls[1][0] == ["openssl", "x509", "-req"]
+    assert "OPENSSL_CONF" not in calls[1][1]["env"]
+
+
 def test_command_error_includes_stderr():
     with pytest.raises(setup_cert.CommandError) as exc:
         setup_cert.run(["openssl", "x509", "-in", "/no/such/file"])


### PR DESCRIPTION
## Problem

`setup_cert.py` retries a rejected SHA-1 signing command with an OpenSSL 3 provider configuration. Apple's `/usr/bin/openssl` is LibreSSL, not OpenSSL 3; LibreSSL can exit successfully after reading that incompatible configuration without executing `openssl x509`. The script then reaches `client.pem` with no certificate present, masking the original signing failure with a later `FileNotFoundError`.

This also makes the existing SHA-1 retry test fail on a clean macOS checkout.

## Root cause

`run_allow_sha1()` assumed every executable named `openssl` understands OpenSSL 3's provider configuration.

## Fix

- Inspect `openssl version` before selecting the retry environment.
- Apply the scoped provider override only to OpenSSL 3.
- Retry LibreSSL and older OpenSSL with a clean environment, removing any inherited `OPENSSL_CONF`.
- Add a deterministic regression test proving LibreSSL never receives the OpenSSL 3 configuration.

## Scope and compatibility

This does not change the generated key, certificate fields, chain, SHA-1 requirement, or any network behavior. Existing OpenSSL 3 behavior is preserved. No certificate or key material is added to the repository.

## Validation

- LibreSSL 3.3.6: `38 passed`
- OpenSSL 3.6.3: `38 passed`
- Focused setup-certificate tests on each CLI: `5 passed`
- Compile check and staged share-safety scan: passed