### PR TITLE
fix(ci): treat sdist VCS-ignore files as optional in distribution check

### DIFF
--- a/tools/check_distribution.py
+++ b/tools/check_distribution.py
@@ -81,16 +81,18 @@ def check_sdist(path: Path) -> None:
         raise DistributionError("sdist must contain one top-level directory")
     root = roots.pop()
     relative = {name[len(root) + 1 :] for name in names if name.startswith(f"{root}/")}
-    expected = _tracked_files() | {
-        ".gitignore",
-        ".hgignore",
+    required = _tracked_files() | {
         "LICENSE",
         "PKG-INFO",
         "README.md",
         "pyproject.toml",
         "smartthings_local/_version.py",
     }
-    if relative != expected:
+    # hatchling bundles the VCS ignore files it finds, but which ones ship
+    # depends on the hatchling version (newer releases drop .hgignore), so
+    # treat them as optional rather than exact members.
+    optional = {".gitignore", ".hgignore"}
+    if not required <= relative <= required | optional:
         raise DistributionError("sdist contents differ from the intended source set")
 
 


### PR DESCRIPTION
The `Validate` workflow's `Package artifacts` job started failing on `main` right after #21 merged:

```
Run python tools/check_distribution.py dist
distribution check failed
Error: Process completed with exit code 1.
```

## Cause

`check_sdist` compared the sdist member list against an exact expected set that hardcoded **`.hgignore`**. hatchling bundles the VCS ignore files it finds, but which ones ship depends on the hatchling version — **1.31.0** (what CI resolved) ships only `.gitignore` in the sdist, while older releases also included `.hgignore`. #21 was validated against an older hatchling, so the exact-match check passed locally and failed in CI.

The wheel check was unaffected.

## Fix

Split the sdist expectation into a **required** set (tracked sources + `LICENSE`, `PKG-INFO`, `README.md`, `pyproject.toml`, `_version.py`) and an **optional** set (`.gitignore`, `.hgignore`). The check now asserts `required <= relative <= required | optional`, so it passes whether hatchling emits one ignore file, both, or neither, while still catching any genuinely unexpected member.

## Validation

- `python -m build` + `python tools/check_distribution.py dist` → `distribution contents verified` (hatchling 1.31.0, Python 3.14)
- `pytest -q` → `52 passed`