### PR TITLE
fix(protocol): keep completed sessions on late cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ retransmissions within that same deadline:
 sess.connect(timeout=4.0)
 ```
 
+The deadline stops further setup, retries, and network waits. If OpenSSL
+reports that the handshake completed at the deadline boundary, the completed
+session is retained rather than torn down as a timeout.
+
 Connection attempts can also use a one-way cancellation signal. The signal is
 backed by a socketpair, so setting it wakes the network wait immediately while
 OpenSSL retains control of DTLS retransmission timing:

--- a/smartthings_local/protocol/dtls_handshake.py
+++ b/smartthings_local/protocol/dtls_handshake.py
@@ -34,14 +34,16 @@ def _drive_dtls_handshake(
     bounded only by its deadline, while the diagnostic probe retains its
     explicit retry budget.
 
-    Return ``True`` only when the handshake completes before the deadline.
-    TLS and socket failures are left to the caller to classify.
+    Return ``True`` once OpenSSL reports the handshake complete. The deadline
+    prevents another setup, retry, or network-wait iteration; it does not tear
+    down a session that completed while ``do_handshake()`` was running. TLS and
+    socket failures are left to the caller to classify.
     """
     retransmits = 0
     while time.monotonic() < deadline:
         try:
             connection.do_handshake()
-            return time.monotonic() < deadline
+            return True
         except SSL.WantReadError:
             pass
 

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -322,13 +322,15 @@ class DtlsCoapSession:
         timeout: float | None = None,
         cancel: ConnectCancellation | None = None,
     ):
-        """Perform a cancellable DTLS handshake within a monotonic deadline.
+        """Perform a cancellable DTLS handshake using a monotonic deadline.
 
         ``timeout`` overrides ``HANDSHAKE_TIMEOUT_S`` for this call. OpenSSL
         owns DTLS retransmission timing while every receive is capped by the
         remaining budget, so wall-clock adjustments cannot change the bound.
-        A ``ConnectCancellation`` wakes the network wait immediately and does
-        not alter an already established session.
+        Once OpenSSL reports completion, that completed session is retained
+        even if the call returns just after the deadline. A
+        ``ConnectCancellation`` wakes the network wait immediately and does not
+        alter an already established session.
         """
         handshake_timeout = _validate_handshake_timeout(
             timeout, self.HANDSHAKE_TIMEOUT_S)

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -382,6 +382,7 @@ class DtlsCoapSession:
         io_failed = False
         cancelled = False
         interrupted = False
+        completed = False
         try:
             try:
                 completed = _drive_dtls_handshake(
@@ -403,7 +404,7 @@ class DtlsCoapSession:
         finally:
             if wake_subscription is not None:
                 interrupted = cancel._unsubscribe(*wake_subscription)
-        if cancelled or interrupted:
+        if cancelled or (interrupted and not completed):
             sock.close()
             raise SessionClosedError()
         if backend_failed:

--- a/tests/test_session_connect_deadline.py
+++ b/tests/test_session_connect_deadline.py
@@ -323,12 +323,12 @@ def test_connect_services_openssl_retransmit_timer(monkeypatch):
 
 
 @pytest.mark.parametrize("success_delay", (0.1, 0.2))
-def test_handshake_success_at_or_after_deadline_is_rejected(
+def test_handshake_success_at_or_after_deadline_is_retained(
     monkeypatch,
     success_delay,
 ):
     clock = _Clock()
-    connection, sock, _endpoint, _open_calls = _install_handshake(
+    connection, sock, endpoint, _open_calls = _install_handshake(
         monkeypatch,
         clock,
     )
@@ -338,7 +338,11 @@ def test_handshake_success_at_or_after_deadline_is_rejected(
 
     connection.do_handshake = late_success
 
-    with pytest.raises(SessionTimeoutError):
-        _session().connect(timeout=0.1)
+    session = _session()
+    session.connect(timeout=0.1)
 
-    assert sock.closed
+    assert session.conn is connection
+    assert session.sock is sock
+    assert session.endpoint is endpoint
+    assert session.dest == endpoint.sockaddr
+    assert not sock.closed

--- a/tests/test_session_interruption.py
+++ b/tests/test_session_interruption.py
@@ -220,9 +220,44 @@ def test_cancel_wakes_blocked_connect_without_poll_latency(monkeypatch):
         peer.close()
 
 
-def test_cancel_wins_race_with_reported_handshake_success(monkeypatch):
+def test_reported_handshake_success_wins_cancel_during_unsubscribe(
+    monkeypatch,
+):
+    class CancelDuringUnsubscribe(ConnectCancellation):
+        def _unsubscribe(self, reader, writer):
+            self.set()
+            return super()._unsubscribe(reader, writer)
+
+    cancel = CancelDuringUnsubscribe()
+    connection = _Connection(succeed=True)
+    data_socket, peer = socket.socketpair()
+    endpoint = _install_connection(monkeypatch, connection, data_socket)
+    session = _session()
+
+    try:
+        session.connect(cancel=cancel)
+        assert cancel.is_set()
+        assert session.sock is data_socket
+        assert session.conn is connection
+        assert session.endpoint is endpoint
+        assert session.dest == endpoint.sockaddr
+        assert not cancel._writers
+    finally:
+        session.close()
+        peer.close()
+
+
+def test_cancel_during_backend_failure_does_not_read_unset_completion(
+    monkeypatch,
+):
     cancel = ConnectCancellation()
-    connection = _Connection(on_success=cancel.set, succeed=True)
+    connection = _Connection()
+
+    def fail_after_cancel():
+        cancel.set()
+        raise SSL.Error("synthetic backend failure")
+
+    connection.do_handshake = fail_after_cancel
     data_socket, peer = socket.socketpair()
     _install_connection(monkeypatch, connection, data_socket)
     session = _session()
@@ -233,6 +268,7 @@ def test_cancel_wins_race_with_reported_handshake_success(monkeypatch):
         assert data_socket.fileno() == -1
         assert session.sock is None
         assert session.conn is None
+        assert not cancel._writers
     finally:
         peer.close()
 


### PR DESCRIPTION
## Summary

- keep an established DTLS session when cancellation is first observed while retiring the connection-attempt wake subscription
- initialize the completion state before the handshake driver so cancellation/error combinations remain well-defined
- cover the exact unsubscribe race and the cancellation-plus-backend-failure path

## Why

This is the follow-up requested in [the merge comment on #35](https://github.com/QuiteYellow/SmartThings-Local/pull/35#issuecomment-5301816072).

After `_drive_dtls_handshake()` returns `completed=True`, `cancel.set()` can race the `finally` block that unsubscribes the socketpair. `_unsubscribe()` then reports `interrupted=True`, and the current condition tears down a handshake that has already completed. Gating that teardown on `not completed` makes the implementation match the documented contract that cancellation does not alter an established session.

Cancellation during setup or a blocked network wait still wins immediately. If the handshake did not complete, a cancellation observed during unsubscribe still closes the temporary socket and raises `SessionClosedError`.

## Merge order

1. #42
2. This PR

This branch contains #42's single commit plus one additional commit for the cancellation race. Once #42 merges, this PR reduces to the second commit.

## Validation

- 238 tests on Python 3.14
- 238 tests on Python 3.11 with `cbor2==5.6.0`, `pyOpenSSL==23.1.0`, and `pytest==8.0.0`
- 1,555 tests from current LocalThings `main` against this exact head
- 25 repeated cancellation-test runs
- focused deadline/interruption tests, compile check, share-safety check, wheel/sdist content check, and isolated imports from both artifacts
