### PR TITLE
docs(protocol): clarify OwnerPSK vector scope

### DIFF
--- a/smartthings_local/protocol/owner_psk.py
+++ b/smartthings_local/protocol/owner_psk.py
@@ -80,6 +80,8 @@ def derive_mfg_certificate_owner_psk(
     It performs no session access, network I/O, ownership writes, or storage.
     The caller must supply state from an authenticated manufacturer-certificate
     session and explicitly select the OXM label used by that transaction.
+    IoTivity's other 96-byte ECDH_ANON, ECDHE_PSK, and ECDHE_RSA mappings are
+    intentionally outside this helper's manufacturer-certificate allowlist.
     """
 
     if not isinstance(cipher_name, str):

--- a/tests/test_owner_psk.py
+++ b/tests/test_owner_psk.py
@@ -23,7 +23,11 @@ _VALID_INPUTS = {
 }
 
 
-def test_fixed_iotivity_gcm_vector():
+# These synthetic expected values were generated from the fixed inputs above;
+# they were not captured from IoTivity or a device. They lock deterministic
+# output for the selected mappings, while the table test below states the
+# key-block-length contract explicitly.
+def test_fixed_synthetic_gcm_regression_vector():
     assert derive_mfg_certificate_owner_psk(**_VALID_INPUTS).hex() == (
         "ccd6c618a91290dee8c106544ed79a33"
     )
@@ -42,7 +46,7 @@ def test_owner_then_device_uuid_order_matches_iotivity_callers():
     assert reversed_context != derive_mfg_certificate_owner_psk(**_VALID_INPUTS)
 
 
-def test_fixed_iotivity_ccm8_vector():
+def test_fixed_synthetic_ccm8_regression_vector():
     inputs = {
         **_VALID_INPUTS,
         "cipher_name": "ECDHE-ECDSA-AES128-CCM8",


### PR DESCRIPTION
## Summary

- rename the two fixed-output tests so they are clearly synthetic regression vectors rather than captures from IoTivity or a device
- record what those values do and do not prove about the derivation
- document that IoTivity's other 96-byte ECDH_ANON, ECDHE_PSK, and ECDHE_RSA mappings are intentionally outside this helper's manufacturer-certificate allowlist

## Why

This follows up on the two non-blocking notes in [the merge comment on #45](https://github.com/QuiteYellow/SmartThings-Local/pull/45#issuecomment-5318816108). The implementation is unchanged; the test provenance and cipher scope are now explicit for the next reader.

## Validation

- SmartThings-Local: 253 tests on Python 3.14
- dependency floor: 253 tests on Python 3.11 with the minimum declared versions
- current LocalThings main: 1,625 tests
- wheel/sdist install checks, distribution, compile, and share-safety checks
