### PR TITLE
feat(protocol): add bounded Block1 POST uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ sess.subscribe(["operational", "state", "vs", "0"],          # OBSERVE
 sess.close()
 ```
 
+`get()` and `post()` accept repeated URI-query strings. They also accept
+ordered `(number, bytes)` options for reviewed OCF extensions while retaining
+ownership of path, query, content-format, Accept, Observe, and blockwise
+options:
+
+```python
+code, body = sess.get(
+    ["oic", "res"],
+    query=("rt=oic.r.doxm",),
+    extra_options=((2049, b"\x08\x00"),),
+)
+```
+
+Path and query text is UTF-8 encoded, and every value is size bounded before
+anything is sent. Additional options remain arbitrary bytes, must already be
+ordered by option number, and may repeat a number when the option is
+repeatable.
+
 `connect()` uses a 12-second monotonic DTLS handshake deadline by default. A
 caller that needs a shorter bounded attempt can pass a positive finite value
 without changing later reader timeouts. OpenSSL's DTLS timer schedules flight

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ repeatable.
 `delete()` uses the same path, query, extension-option, timeout, and response
 contract without sending a request payload.
 
+POST bodies through 1024 bytes retain the single-request behavior. Larger
+bodies use token-stable Block1 requests under one monotonic timeout, include
+Size1 on the first request, honor a server-requested smaller block size, and
+return only the final response. Upload bodies are limited to 512 KiB and 1024
+block requests; incomplete or contradictory success acknowledgements fail as
+`BlockwiseError`.
+
 `connect()` uses a 12-second monotonic DTLS handshake deadline by default. A
 caller that needs a shorter bounded attempt can pass a positive finite value
 without changing later reader timeouts. OpenSSL's DTLS timer schedules flight

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ anything is sent. Additional options remain arbitrary bytes, must already be
 ordered by option number, and may repeat a number when the option is
 repeatable.
 
+`delete()` uses the same path, query, extension-option, timeout, and response
+contract without sending a request payload.
+
 `connect()` uses a 12-second monotonic DTLS handshake deadline by default. A
 caller that needs a shorter bounded attempt can pass a positive finite value
 without changing later reader timeouts. OpenSSL's DTLS timer schedules flight

--- a/smartthings_local/protocol/coap.py
+++ b/smartthings_local/protocol/coap.py
@@ -31,6 +31,7 @@ TYPE_RST = 3
 # CoAP method codes
 METHOD_GET  = 0x01
 METHOD_POST = 0x02
+METHOD_DELETE = 0x04
 
 # CoAP content-format value for application/cbor
 CF_CBOR = b'\x3c'

--- a/smartthings_local/protocol/coap.py
+++ b/smartthings_local/protocol/coap.py
@@ -18,7 +18,9 @@ ETAG           =  4
 CONTENT_FORMAT = 12
 ACCEPT         = 17
 BLOCK2         = 23
+BLOCK1         = 27
 SIZE2          = 28
+SIZE1          = 60
 
 # CoAP message types
 TYPE_CON = 0
@@ -249,12 +251,13 @@ def _option_bytes(value, *, name):
 
 def build_get_request(
         mtype, mid, token, path_segs, query=(), *, accept=CF_CBOR,
-        block_number=None, block_szx=BLOCK_SZX):
-    """Build a GET with optional Uri-Query, Accept, and Block2 options.
+        block_number=None, block_szx=BLOCK_SZX, extra_options=()):
+    """Build a GET with optional query, Block2, and extension options.
 
     ``block_number=None`` omits Block2 for the initial request.  Continuation
     requests pass the accumulator's ``expected_number`` and ``szx``.  Path and
-    query values may be either text or already encoded bytes.
+    query values may be either text or already encoded bytes. Extension
+    options are expected to have been validated by the session.
     """
     options = [
         (URI_PATH, _option_bytes(segment, name='path segment'))
@@ -278,6 +281,7 @@ def build_get_request(
                 or not 0 <= block_szx <= BLOCK_SZX):
             raise ValueError('block_szx must be between 0 and 6')
         options.append((BLOCK2, block_value(block_number, 0, block_szx)))
+    options.extend(extra_options)
     return build_coap(mtype, METHOD_GET, mid, token, options)
 
 

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -54,6 +54,7 @@ from .auth import (
 )
 from .coap import (
     ACCEPT,
+    BLOCK1,
     BLOCK2,
     BLOCK2_COMPLETE,
     CF_CBOR,
@@ -67,8 +68,11 @@ from .coap import (
     RESPONSE_EMPTY_ACK,
     RESPONSE_MESSAGE,
     RESPONSE_RESET,
+    SIZE1,
+    SIZE2,
     TYPE_CON,
     URI_PATH,
+    URI_QUERY,
     Block2Accumulator,
     block_fields,
     build_coap,
@@ -176,6 +180,75 @@ def _validate_handshake_timeout(timeout, default):
     if not math.isfinite(value) or value <= 0:
         raise ValueError('timeout must be a positive finite number or None')
     return value
+
+
+_MAX_REQUEST_OPTION_BYTES = 1024
+_MAX_REQUEST_OPTION_COUNT = 32
+_MAX_REQUEST_OPTION_NUMBER = 65535
+_MANAGED_REQUEST_OPTIONS = frozenset((
+    URI_PATH, URI_QUERY, OBSERVE, CONTENT_FORMAT, ACCEPT,
+    BLOCK2, BLOCK1, SIZE2, SIZE1,
+))
+
+
+def _validated_text_options(values, *, name, allow_empty):
+    """Return bounded UTF-8 option values without echoing caller data."""
+    if isinstance(values, (str, bytes, bytearray, memoryview)):
+        raise TypeError(f'{name} must be an iterable of strings')
+    try:
+        iterator = iter(values)
+    except TypeError:
+        raise TypeError(f'{name} must be an iterable of strings') from None
+    result = []
+    for value in iterator:
+        if len(result) >= _MAX_REQUEST_OPTION_COUNT:
+            raise ValueError(f'{name} must contain at most 32 values')
+        if not isinstance(value, str):
+            raise TypeError(f'{name} values must be strings')
+        try:
+            encoded = value.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ValueError(f'{name} values must be valid UTF-8') from None
+        if (not allow_empty and not encoded) or \
+                len(encoded) > _MAX_REQUEST_OPTION_BYTES:
+            raise ValueError(f'{name} values must be non-empty and bounded')
+        result.append(value)
+    return tuple(result)
+
+
+def _validated_extra_options(extra_options):
+    """Return bounded, ordered options not owned by the request methods."""
+    if isinstance(extra_options, (str, bytes, bytearray, memoryview)):
+        raise TypeError('extra_options must contain (number, bytes) tuples')
+    try:
+        iterator = iter(extra_options)
+    except TypeError:
+        raise TypeError(
+            'extra_options must contain (number, bytes) tuples') from None
+    result = []
+    previous = -1
+    for item in iterator:
+        if len(result) >= _MAX_REQUEST_OPTION_COUNT:
+            raise ValueError('extra_options must contain at most 32 values')
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError(
+                'extra_options must contain (number, bytes) tuples')
+        number, value = item
+        if isinstance(number, bool) or not isinstance(number, int):
+            raise TypeError('extra option numbers must be integers')
+        if not 1 <= number <= _MAX_REQUEST_OPTION_NUMBER:
+            raise ValueError('extra option numbers must be bounded')
+        if number < previous:
+            raise ValueError('extra options must be ordered by number')
+        if number in _MANAGED_REQUEST_OPTIONS:
+            raise ValueError('extra option is managed by the CoAP transport')
+        if not isinstance(value, bytes):
+            raise TypeError('extra option values must be bytes')
+        if len(value) > _MAX_REQUEST_OPTION_BYTES:
+            raise ValueError('extra option values must be bounded')
+        result.append((number, value))
+        previous = number
+    return tuple(result)
 
 
 class ConnectCancellation:
@@ -958,7 +1031,7 @@ class DtlsCoapSession:
 
     # ---- request primitives ------------------------------------------
 
-    def get(self, path_segs, query=(), timeout=10.0):
+    def get(self, path_segs, query=(), timeout=10.0, *, extra_options=()):
         """Token-stable Block2 GET. Returns (code, payload_bytes).
 
         Reuses one CoAP token across every block of a multi-block
@@ -966,11 +1039,17 @@ class DtlsCoapSession:
         token, and dropping a fresh token on block 1+ silently drops
         the request."""
         self._check_live()
+        path_segs = _validated_text_options(
+            path_segs, name='path_segs', allow_empty=False)
+        query = _validated_text_options(
+            query, name='query', allow_empty=False)
+        extra_options = _validated_extra_options(extra_options)
         code, blob, _blocks, _tok = self._blockwise_get(
-            path_segs, query, timeout)
+            path_segs, query, timeout, extra_options=extra_options)
         return code, blob
 
-    def _blockwise_get(self, path_segs, query=(), timeout=10.0):
+    def _blockwise_get(
+            self, path_segs, query=(), timeout=10.0, *, extra_options=()):
         """Shared token-stable Block2 reassembly (RFC 7959 §2.4).
 
         Returns (code, payload, block_count, token). The last two are
@@ -989,19 +1068,22 @@ class DtlsCoapSession:
         when the server supplies them. None of the tested appliances
         emit option 4, so on those this is inert."""
         try:
-            return self._blockwise_get_once(path_segs, query, timeout)
+            return self._blockwise_get_once(
+                path_segs, query, timeout, extra_options)
         except _EtagChanged:
             logger.debug("GET %s /%s: ETag changed mid-transfer, restarting",
                          self.host, '/'.join(path_segs))
         try:
-            return self._blockwise_get_once(path_segs, query, timeout)
+            return self._blockwise_get_once(
+                path_segs, query, timeout, extra_options)
         except _EtagChanged:
             logger.debug(
                 "GET %s /%s: representation kept changing mid-transfer",
                 self.host, '/'.join(path_segs))
             raise BlockwiseError() from None
 
-    def _blockwise_get_once(self, path_segs, query, timeout):
+    def _blockwise_get_once(
+            self, path_segs, query, timeout, extra_options):
         """One attempt at a full Block2 transfer. Raises _EtagChanged if
         the server's representation changed while we were reassembling."""
         tok = self._next_tok()
@@ -1018,6 +1100,7 @@ class DtlsCoapSession:
                 num,
                 accumulator.szx,
                 deadline,
+                extra_options,
             )
             prior_blocks = accumulator.blocks_received
 
@@ -1045,7 +1128,9 @@ class DtlsCoapSession:
 
         raise BlockwiseError()
 
-    def _exchange_block(self, tok, path_segs, query, num, szx, deadline):
+    def _exchange_block(
+            self, tok, path_segs, query, num, szx, deadline,
+            extra_options):
         """Send one block request under `tok` and return its response
         message, retransmitting up to _BLOCK_MAX_ATTEMPTS times.
 
@@ -1070,6 +1155,7 @@ class DtlsCoapSession:
             query,
             block_number=num if num > 0 else None,
             block_szx=szx,
+            extra_options=extra_options,
         )
         try:
             for attempt in range(_BLOCK_MAX_ATTEMPTS):
@@ -1167,7 +1253,9 @@ class DtlsCoapSession:
         response_offset = response_num << (response_szx + 4)
         return response_offset == requested_offset
 
-    def post(self, path_segs, body_cbor, timeout=8.0):
+    def post(
+            self, path_segs, body_cbor, timeout=8.0, *, query=(),
+            extra_options=()):
         """Single-frame POST with a CBOR-encoded body. Returns
         (code, payload_bytes). body_cbor must already be encoded.
 
@@ -1181,10 +1269,20 @@ class DtlsCoapSession:
         retry cannot offer that, since it mints a fresh MID and token.
         Defaults to one attempt — see _WRITE_ACK_TIMEOUT."""
         self._check_live()
+        path_segs = _validated_text_options(
+            path_segs, name='path_segs', allow_empty=False)
+        query = _validated_text_options(
+            query, name='query', allow_empty=False)
+        extra_options = _validated_extra_options(extra_options)
+        if not isinstance(body_cbor, bytes):
+            raise TypeError('body_cbor must be bytes')
         tok = self._next_tok()
         opts = [(URI_PATH, s.encode()) for s in path_segs]
+        for q in query:
+            opts.append((URI_QUERY, q.encode()))
         opts.append((CONTENT_FORMAT, CF_CBOR))
         opts.append((ACCEPT, CF_CBOR))
+        opts.extend(extra_options)
         ev = threading.Event()
         container = {}
         mid, exchange = self._register_pending_request(tok, ev, container)

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -57,6 +57,7 @@ from .coap import (
     BLOCK1,
     BLOCK2,
     BLOCK2_COMPLETE,
+    BLOCK_SZX,
     CF_CBOR,
     CONTENT_FORMAT,
     ETAG,
@@ -76,6 +77,7 @@ from .coap import (
     URI_QUERY,
     Block2Accumulator,
     block_fields,
+    block_value,
     build_coap,
     build_get_request,
     classify_coap_response,
@@ -108,6 +110,8 @@ DEBUG_BRIDGE = os.environ.get('DEBUG_BRIDGE') == '1'
 # overall deadline). Matches RFC 7252 CON retransmit behaviour.
 _BLOCK_MAX_ATTEMPTS = 3
 _BLOCK_ACK_TIMEOUT  = 4.0
+_MAX_BLOCK1_BODY_BYTES = 512 * 1024
+_MAX_BLOCK1_REQUESTS = 1024
 
 # Base per-attempt wait for a write retransmission, doubled per attempt
 # (RFC 7252 §4.2). Retransmission itself is off by default: a device that
@@ -883,17 +887,22 @@ class DtlsCoapSession:
         if classification.kind != RESPONSE_MESSAGE:
             return
 
-        # Pending one-shot? Resolve and return.
+        # Pending one-shot? Resolve and return. Block1 keeps one token for the
+        # entire upload, so a delayed response for the previous chunk must not
+        # resolve the currently registered chunk.
         with self._state_lock:
             rec = self._pending.get(tok)
             if rec is not None:
                 ev, container = rec
-                container['code']    = code
-                container['mtype']   = mt
-                container['mid']     = mid
-                container['options'] = ropts
-                container['payload'] = payload
-                container['message'] = message
+                if self._block1_response_matches(message, container):
+                    container['code']    = code
+                    container['mtype']   = mt
+                    container['mid']     = mid
+                    container['options'] = ropts
+                    container['payload'] = payload
+                    container['message'] = message
+                else:
+                    rec = None
         if rec is not None:
             ev.set()
             return
@@ -1254,11 +1263,49 @@ class DtlsCoapSession:
         response_offset = response_num << (response_szx + 4)
         return response_offset == requested_offset
 
+    @staticmethod
+    def _block1_response_matches(message, container):
+        """Return whether ``message`` can answer the pending Block1 chunk.
+
+        A Block1 upload deliberately reuses its token across every chunk.
+        Samsung can deliver an acknowledgement for the previous chunk after
+        the next one is registered, so successful responses that carry Block1
+        must cover the byte range currently pending. Responses without Block1
+        are left to the caller's protocol validation: errors and a final 2.xx
+        response may legitimately omit it, while an intermediate 2.31 may not.
+        """
+        expected_start = container.get('expected_block1_start')
+        if message.code >> 5 != 2 or expected_start is None:
+            return True
+        block_values = [
+            value for number, value in message.options if number == BLOCK1]
+        if not block_values:
+            return True
+        if len(block_values) != 1 or len(block_values[0]) > 3:
+            return False
+        response_num, _response_more, response_szx = \
+            block_fields(block_values[0])
+        if response_szx > BLOCK_SZX:
+            return False
+        response_size = 1 << (response_szx + 4)
+        response_start = response_num * response_size
+        response_end = response_start + response_size
+        expected_end = container['expected_block1_end']
+        if container['expected_block1_more']:
+            return response_end == expected_end
+        return (
+            response_start <= expected_start < response_end
+            and expected_end <= response_end
+        )
+
     def post(
             self, path_segs, body_cbor, timeout=8.0, *, query=(),
             extra_options=()):
-        """Single-frame POST with a CBOR-encoded body. Returns
-        (code, payload_bytes). body_cbor must already be encoded.
+        """POST a CBOR-encoded body and return (code, payload_bytes).
+
+        Bodies through one 1024-byte OCF block retain the single-frame path.
+        Larger bodies use token-stable Block1 framing. ``body_cbor`` must
+        already be encoded.
 
         timeout bounds the whole call, pacing included, so post() returns
         within it rather than within it plus a rate-limit interval.
@@ -1277,12 +1324,23 @@ class DtlsCoapSession:
         extra_options = _validated_extra_options(extra_options)
         if not isinstance(body_cbor, bytes):
             raise TypeError('body_cbor must be bytes')
-        tok = self._next_tok()
+        if len(body_cbor) > _MAX_BLOCK1_BODY_BYTES:
+            raise ValueError('body_cbor must contain at most 524288 bytes')
+        block_size = 1 << (BLOCK_SZX + 4)
         opts = [(URI_PATH, s.encode()) for s in path_segs]
         for q in query:
             opts.append((URI_QUERY, q.encode()))
         opts.append((CONTENT_FORMAT, CF_CBOR))
         opts.append((ACCEPT, CF_CBOR))
+        if len(body_cbor) > block_size:
+            return self._post_blockwise(
+                path_segs,
+                body_cbor,
+                opts,
+                extra_options,
+                timeout=timeout,
+            )
+        tok = self._next_tok()
         opts.extend(extra_options)
         ev = threading.Event()
         container = {}
@@ -1376,6 +1434,173 @@ class DtlsCoapSession:
                 logger.debug(
                     "POST %s /%s: attempt %d/%d timeout, retransmitting",
                     self.host, '/'.join(path_segs), attempt + 1, attempts,
+                )
+            raise SessionTimeoutError()
+        finally:
+            self._unregister_pending_request(tok, mid, exchange)
+
+    def _post_blockwise(
+            self, path_segs, body_cbor, base_options, extra_options, *,
+            timeout):
+        """Upload one bounded body with token-stable Block1 framing."""
+        tok = self._next_tok()
+        deadline = time.monotonic() + timeout
+        offset = 0
+        szx = BLOCK_SZX
+        request_count = 0
+
+        while offset < len(body_cbor):
+            self._check_live()
+            block_size = 1 << (szx + 4)
+            if offset % block_size:
+                raise BlockwiseError()
+            num = offset // block_size
+            chunk = body_cbor[offset:offset + block_size]
+            end_offset = offset + len(chunk)
+            more = int(end_offset < len(body_cbor))
+            request_count += 1
+            if request_count > _MAX_BLOCK1_REQUESTS:
+                raise BlockwiseError()
+
+            opts = list(base_options)
+            opts.append((BLOCK1, block_value(num, more, szx)))
+            if offset == 0:
+                size_width = max(
+                    1, (len(body_cbor).bit_length() + 7) // 8)
+                opts.append((
+                    SIZE1,
+                    len(body_cbor).to_bytes(size_width, 'big'),
+                ))
+            opts.extend(extra_options)
+            message = self._exchange_block1(
+                tok,
+                path_segs,
+                opts,
+                chunk,
+                block_num=num,
+                start=offset,
+                end=end_offset,
+                more=more,
+                deadline=deadline,
+            )
+            code = message.code
+            payload = message.payload
+            response_blocks = [
+                value for number, value in message.options
+                if number == BLOCK1]
+
+            if more:
+                if code != 0x5F:
+                    if code >> 5 == 2:
+                        raise BlockwiseError()
+                    return code, payload
+                if len(response_blocks) > 1:
+                    raise BlockwiseError()
+                if not response_blocks or len(response_blocks[0]) > 3:
+                    raise BlockwiseError()
+                _response_num, response_more, response_szx = \
+                    block_fields(response_blocks[0])
+                if not response_more or response_szx > szx:
+                    raise BlockwiseError()
+                szx = response_szx
+                if offset % (1 << (szx + 4)):
+                    raise BlockwiseError()
+                offset = end_offset
+                continue
+
+            if code >> 5 != 2:
+                return code, payload
+            if code == 0x5F:
+                raise BlockwiseError()
+            if len(response_blocks) > 1:
+                raise BlockwiseError()
+            if response_blocks:
+                block = response_blocks[0]
+                if len(block) > 3:
+                    raise BlockwiseError()
+                _response_num, response_more, response_szx = \
+                    block_fields(block)
+                if response_more or response_szx > szx:
+                    raise BlockwiseError()
+            return code, payload
+
+        raise BlockwiseError()
+
+    def _exchange_block1(
+            self, tok, path_segs, options, payload, *, block_num, start, end,
+            more, deadline):
+        """Send one Block1 chunk under a stable token and Message ID."""
+        ev = threading.Event()
+        container = {
+            'expected_block1_start': start,
+            'expected_block1_end': end,
+            'expected_block1_more': more,
+        }
+        mid, exchange = self._register_pending_request(tok, ev, container)
+        try:
+            datagram = build_coap(
+                TYPE_CON, METHOD_POST, mid, tok, options, payload)
+            for attempt in range(_BLOCK_MAX_ATTEMPTS):
+                self.pace()
+                with self._state_lock:
+                    error = container.get('err')
+                    message = container.get('message')
+                    acknowledged = exchange.acknowledged
+                # A response may land while a retry is being paced. Honour it
+                # before checking reader liveness so a response dispatched just
+                # before teardown is not discarded or resent.
+                if error is not None:
+                    raise error
+                if message is not None:
+                    return message
+                self._check_live()
+                if time.monotonic() >= deadline:
+                    raise SessionTimeoutError()
+                if not acknowledged:
+                    try:
+                        self._send_dgram(datagram)
+                    except EndpointError:
+                        if not attempt:
+                            raise
+                        logger.debug(
+                            "POST %s /%s block %d: retransmit %d/%d "
+                            "send failed",
+                            self.host, '/'.join(path_segs), block_num,
+                            attempt + 1, _BLOCK_MAX_ATTEMPTS,
+                        )
+
+                last = attempt == _BLOCK_MAX_ATTEMPTS - 1
+                while True:
+                    with self._state_lock:
+                        error = container.get('err')
+                        message = container.get('message')
+                        if error is None and message is None:
+                            ev.clear()
+                        acknowledged = exchange.acknowledged
+                    if error is not None:
+                        raise error
+                    if message is not None:
+                        return message
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise SessionTimeoutError()
+                    per_wait = (
+                        remaining if acknowledged
+                        else min(_BLOCK_ACK_TIMEOUT, remaining)
+                    )
+                    if self._wait_live(ev, per_wait):
+                        continue
+                    if acknowledged or last:
+                        raise SessionTimeoutError()
+                    break
+
+                if deadline - time.monotonic() <= self._min_req_interval:
+                    break
+                logger.debug(
+                    "POST %s /%s block %d: attempt %d/%d timeout, "
+                    "retransmitting",
+                    self.host, '/'.join(path_segs), block_num,
+                    attempt + 1, _BLOCK_MAX_ATTEMPTS,
                 )
             raise SessionTimeoutError()
         finally:

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -60,6 +60,7 @@ from .coap import (
     CF_CBOR,
     CONTENT_FORMAT,
     ETAG,
+    METHOD_DELETE,
     METHOD_GET,
     METHOD_POST,
     OBSERVE,
@@ -1377,6 +1378,53 @@ class DtlsCoapSession:
                     self.host, '/'.join(path_segs), attempt + 1, attempts,
                 )
             raise SessionTimeoutError()
+        finally:
+            self._unregister_pending_request(tok, mid, exchange)
+
+    def delete(
+            self, path_segs, timeout=8.0, *, query=(), extra_options=()):
+        """Single-frame DELETE. Returns (code, payload_bytes).
+
+        ``timeout`` bounds the whole call, including request pacing.
+        """
+        self._check_live()
+        path_segs = _validated_text_options(
+            path_segs, name='path_segs', allow_empty=False)
+        query = _validated_text_options(
+            query, name='query', allow_empty=False)
+        extra_options = _validated_extra_options(extra_options)
+        tok = self._next_tok()
+        opts = [(URI_PATH, s.encode()) for s in path_segs]
+        for q in query:
+            opts.append((URI_QUERY, q.encode()))
+        opts.append((ACCEPT, CF_CBOR))
+        opts.extend(extra_options)
+        ev = threading.Event()
+        container = {}
+        mid, exchange = self._register_pending_request(tok, ev, container)
+        datagram = build_coap(TYPE_CON, METHOD_DELETE, mid, tok, opts)
+        deadline = time.time() + timeout
+        try:
+            self.pace()
+            self._check_live()
+            self._send_dgram(datagram)
+            while True:
+                with self._state_lock:
+                    error = container.get('err')
+                    has_response = 'code' in container
+                    response = (
+                        (container['code'], container['payload'])
+                        if has_response else None
+                    )
+                    if error is None and not has_response:
+                        ev.clear()
+                if error is not None:
+                    raise error
+                if has_response:
+                    return response
+                remaining = deadline - time.time()
+                if remaining <= 0 or not self._wait_live(ev, remaining):
+                    raise SessionTimeoutError()
         finally:
             self._unregister_pending_request(tok, mid, exchange)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -156,6 +156,7 @@ def test_handshake_error_is_classified_without_backend_text(monkeypatch):
     (
         lambda session: session.get(['resource']),
         lambda session: session.post(['resource'], b'payload'),
+        lambda session: session.delete(['resource']),
         lambda session: session.ping(),
         lambda session: session.refresh_observes([]),
         lambda session: session.subscribe(['resource']),

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -206,6 +206,11 @@ def test_dtls_session_keeps_current_consumer_methods():
             "timeout",
         ],
     )
+    get_extra_options = inspect.signature(DtlsCoapSession.get).parameters[
+        "extra_options"
+    ]
+    assert get_extra_options.kind is inspect.Parameter.KEYWORD_ONLY
+    assert get_extra_options.default == ()
     _assert_compatible_signature(
         DtlsCoapSession.post,
         [
@@ -215,6 +220,10 @@ def test_dtls_session_keeps_current_consumer_methods():
             "timeout",
         ],
     )
+    post_parameters = inspect.signature(DtlsCoapSession.post).parameters
+    for name in ("query", "extra_options"):
+        assert post_parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert post_parameters[name].default == ()
     _assert_compatible_signature(
         DtlsCoapSession.subscribe,
         ["self", "path_segs"],

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -173,6 +173,7 @@ def test_dtls_session_keeps_current_consumer_methods():
     expected = {
         "close",
         "connect",
+        "delete",
         "get",
         "join",
         "pace",
@@ -224,6 +225,18 @@ def test_dtls_session_keeps_current_consumer_methods():
     for name in ("query", "extra_options"):
         assert post_parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
         assert post_parameters[name].default == ()
+    _assert_compatible_signature(
+        DtlsCoapSession.delete,
+        [
+            "self",
+            "path_segs",
+            "timeout",
+        ],
+    )
+    delete_parameters = inspect.signature(DtlsCoapSession.delete).parameters
+    for name in ("query", "extra_options"):
+        assert delete_parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert delete_parameters[name].default == ()
     _assert_compatible_signature(
         DtlsCoapSession.subscribe,
         ["self", "path_segs"],

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import threading
+import time
+
 import pytest
 
 import smartthings_local.protocol.dtls_session as dtls_session
 from smartthings_local.errors import (
+    BlockwiseError,
     SessionClosedError,
     SessionResetError,
     SessionTimeoutError,
@@ -22,6 +26,7 @@ from smartthings_local.protocol.coap import (
     SIZE1,
     SIZE2,
     TYPE_ACK,
+    TYPE_NON,
     TYPE_RST,
     URI_PATH,
     URI_QUERY,
@@ -55,16 +60,34 @@ def _session(responder, **session_kwargs):
         request = parse_coap(datagram)
         requests.append(request)
         response = responder(request, len(requests) - 1)
-        if response is not None:
-            session._dispatch_coap(response)
+        if response is None:
+            return
+        responses = response if isinstance(response, (list, tuple)) else (response,)
+        for item in responses:
+            session._dispatch_coap(item)
 
     session._send_dgram = send
     return session, requests
 
 
-def _response(request, payload=b"ok", *, options=()):
+def _response(request, payload=b"ok", *, code=0x45, options=()):
     _mtype, _code, mid, token, _options, _payload = request
-    return build_coap(TYPE_ACK, 0x45, mid, token, options, payload)
+    return build_coap(TYPE_ACK, code, mid, token, options, payload)
+
+
+def _block1_response(request, *, block=None, code=None, payload=b""):
+    request_block = next(value for number, value in request[4] if number == BLOCK1)
+    _num, more, _szx = dtls_session.block_fields(request_block)
+    if block is None:
+        block = request_block
+    if code is None:
+        code = 0x5F if more else 0x44
+    return _response(
+        request,
+        payload,
+        code=code,
+        options=((BLOCK1, block),),
+    )
 
 
 def test_get_keeps_query_and_extra_options_on_every_block():
@@ -192,6 +215,380 @@ def test_post_retransmission_keeps_query_and_extension_wire_bytes(monkeypatch):
     ]
     assert _VERSION_OPTION in requests[1][4]
     assert _ROUTING_OPTION in requests[1][4]
+
+
+@pytest.mark.parametrize(
+    ("body_size", "chunk_sizes"),
+    (
+        (1024, [1024]),
+        (1025, [1024, 1]),
+        (2048, [1024, 1024]),
+        (2049, [1024, 1024, 1]),
+    ),
+)
+def test_post_uses_block1_only_above_one_ocf_block(body_size, chunk_sizes):
+    body = bytes(range(256)) * (body_size // 256) + bytes(range(body_size % 256))
+
+    def respond(request, _number):
+        if any(number == BLOCK1 for number, _value in request[4]):
+            return _block1_response(request)
+        return _response(request, b"final", code=0x44)
+
+    session, requests = _session(respond)
+    expected_payload = b"final" if body_size <= 1024 else b""
+    assert session.post(["resource"], body) == (0x44, expected_payload)
+
+    assert [len(request[5]) for request in requests] == chunk_sizes
+    assert b"".join(request[5] for request in requests) == body
+    if body_size <= 1024:
+        assert not any(number == BLOCK1 for number, _value in requests[0][4])
+        assert not any(number == SIZE1 for number, _value in requests[0][4])
+        return
+    assert len({request[3] for request in requests}) == 1
+    assert len({request[2] for request in requests}) == len(requests)
+    first_size = next(value for number, value in requests[0][4] if number == SIZE1)
+    assert int.from_bytes(first_size, "big") == body_size
+    assert all(
+        not any(number == SIZE1 for number, _value in request[4])
+        for request in requests[1:]
+    )
+
+
+def test_block1_keeps_queries_and_extensions_on_every_request():
+    session, requests = _session(lambda request, _number: _block1_response(request))
+    body = b"x" * 2050
+
+    assert session.post(
+        ["oic", "sec", "cred"],
+        body,
+        query=("if=oic.if.b",),
+        extra_options=(_VERSION_OPTION, _ROUTING_OPTION),
+    ) == (0x44, b"")
+
+    assert len(requests) == 3
+    for request in requests:
+        assert (URI_QUERY, b"if=oic.if.b") in request[4]
+        assert _VERSION_OPTION in request[4]
+        assert _ROUTING_OPTION in request[4]
+
+
+def test_block1_honours_a_smaller_server_block_size():
+    body = b"x" * 1600
+
+    def respond(request, request_number):
+        request_block = next(value for number, value in request[4] if number == BLOCK1)
+        if request_number == 0:
+            return _block1_response(request, block=block_value(1, 1, 5))
+        return _block1_response(request, block=request_block)
+
+    session, requests = _session(respond)
+    assert session.post(["oic", "sec", "cred"], body) == (0x44, b"")
+
+    assert [len(request[5]) for request in requests] == [1024, 512, 64]
+    assert [
+        next(value for number, value in request[4] if number == BLOCK1)
+        for request in requests
+    ] == [
+        block_value(0, 1, 6),
+        block_value(2, 1, 5),
+        block_value(3, 0, 5),
+    ]
+
+
+def test_block1_ignores_a_late_acknowledgement_for_the_previous_chunk():
+    first_response = None
+
+    def respond(request, request_number):
+        nonlocal first_response
+        response = _block1_response(request)
+        if request_number == 0:
+            first_response = response
+            return response
+        if request_number == 1:
+            return [first_response, response]
+        return response
+
+    session, requests = _session(respond)
+    assert session.post(["resource"], b"x" * 2049) == (0x44, b"")
+    assert len(requests) == 3
+
+
+def test_block1_retransmits_the_identical_request(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.01)
+
+    def respond(request, request_number):
+        if request_number == 0:
+            return None
+        return _block1_response(request)
+
+    session, requests = _session(respond)
+    datagrams = []
+    send = session._send_dgram
+
+    def record_and_send(datagram):
+        datagrams.append(datagram)
+        send(datagram)
+
+    session._send_dgram = record_and_send
+    assert session.post(["resource"], b"x" * 1025, timeout=1.0) == (0x44, b"")
+
+    assert requests[0] == requests[1]
+    assert datagrams[0] == datagrams[1]
+    assert requests[0][2] == requests[1][2]
+    assert requests[0][3] == requests[1][3]
+
+
+def test_block1_response_during_retry_pace_is_not_resent(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+
+    def respond(request, request_number):
+        if request_number == 0:
+            return None
+        return _block1_response(request)
+
+    session, requests = _session(respond)
+    pace_count = 0
+
+    def pace():
+        nonlocal pace_count
+        pace_count += 1
+        if pace_count == 2:
+            session._dispatch_coap(_block1_response(requests[0]))
+
+    session.pace = pace
+
+    assert session.post(["resource"], b"x" * 1025, timeout=1.0) == (0x44, b"")
+    assert len(requests) == 2
+    assert requests[0][5] == b"x" * 1024
+    assert requests[1][5] == b"x"
+
+
+def test_block1_final_response_beats_reader_teardown_during_retry_pace(
+    monkeypatch,
+):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+
+    def respond(request, request_number):
+        if request_number == 0:
+            return _block1_response(request)
+        return None
+
+    session, requests = _session(respond)
+    session._reader_thread = object()
+    session._reader_running.set()
+    pace_count = 0
+
+    def pace():
+        nonlocal pace_count
+        pace_count += 1
+        if pace_count == 3:
+            session._dispatch_coap(_block1_response(requests[1]))
+            session._reader_running.clear()
+            session._close_pending_requests()
+
+    session.pace = pace
+
+    assert session.post(["resource"], b"x" * 1025, timeout=1.0) == (0x44, b"")
+    assert len(requests) == 2
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_block1_empty_ack_stops_retry_until_separate_response(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+    session = None
+    delivery = None
+
+    def respond(request, request_number):
+        nonlocal delivery
+        if request_number:
+            return _block1_response(request)
+        _mtype, _code, mid, token, options, _payload = request
+        block = next(value for number, value in options if number == BLOCK1)
+
+        def deliver_separate_response():
+            time.sleep(0.01)
+            session._dispatch_coap(build_coap(
+                TYPE_NON,
+                0x5F,
+                (mid + 1) & 0xFFFF,
+                token,
+                ((BLOCK1, block),),
+            ))
+
+        delivery = threading.Thread(target=deliver_separate_response)
+        delivery.start()
+        return build_coap(TYPE_ACK, 0, mid, b"", ())
+
+    session, requests = _session(respond)
+    assert session.post(["resource"], b"x" * 1025, timeout=1.0) == (0x44, b"")
+    delivery.join()
+
+    assert len(requests) == 2
+    assert requests[0][5] == b"x" * 1024
+    assert requests[1][5] == b"x"
+
+
+def test_block1_reset_uses_shared_mid_registry_and_cleans_up():
+    def reset(request, _request_number):
+        _mtype, _code, mid, _token, _options, _payload = request
+        return build_coap(TYPE_RST, 0, mid, b"", ())
+
+    session, requests = _session(reset)
+    with pytest.raises(SessionResetError):
+        session.post(["resource"], b"x" * 1025)
+
+    assert len(requests) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_block1_does_not_allocate_an_ordinary_post_exchange():
+    session, requests = _session(lambda request, _number: _block1_response(request))
+    registrations = []
+    register = session._register_pending_request
+
+    def record_registration(token, event, container):
+        registrations.append(token)
+        return register(token, event, container)
+
+    session._register_pending_request = record_registration
+    session._next_mid = lambda: pytest.fail("Block1 bypassed the shared registry")
+
+    assert session.post(["resource"], b"x" * 1025) == (0x44, b"")
+    assert len(requests) == 2
+    assert registrations == [requests[0][3], requests[1][3]]
+    assert len(set(registrations)) == 1
+
+
+def test_write_attempt_setting_does_not_multiply_block1_attempts(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+    session, requests = _session(
+        lambda _request, _number: None,
+        write_max_attempts=10,
+    )
+
+    with pytest.raises(SessionTimeoutError):
+        session.post(["resource"], b"x" * 1025, timeout=0.05)
+
+    assert len(requests) == dtls_session._BLOCK_MAX_ATTEMPTS
+    assert len({request[2] for request in requests}) == 1
+    assert len({request[3] for request in requests}) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_block1_attempt_wait_does_not_expand_to_caller_deadline(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+    session, requests = _session(lambda _request, _number: None)
+
+    started = time.monotonic()
+    with pytest.raises(SessionTimeoutError):
+        session.post(["resource"], b"x" * 1025, timeout=1.0)
+    elapsed = time.monotonic() - started
+
+    assert len(requests) == dtls_session._BLOCK_MAX_ATTEMPTS
+    assert elapsed < 0.25
+
+
+def test_block1_builder_failure_retires_pending_exchange(monkeypatch):
+    session, requests = _session(lambda request, _number: _block1_response(request))
+
+    def fail_build(*_args, **_kwargs):
+        raise ValueError("synthetic wire failure")
+
+    monkeypatch.setattr(dtls_session, "build_coap", fail_build)
+    with pytest.raises(ValueError, match="synthetic wire failure"):
+        session.post(["resource"], b"x" * 1025)
+
+    assert requests == []
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+@pytest.mark.parametrize(
+    ("response", "error_type"),
+    (
+        (lambda request: _response(request, code=0x44), BlockwiseError),
+        (lambda request: _response(request, code=0x5F), BlockwiseError),
+        (
+            lambda request: _block1_response(
+                request, block=block_value(0, 0, 6), code=0x5F
+            ),
+            BlockwiseError,
+        ),
+        (
+            lambda request: _block1_response(
+                request, block=block_value(0, 1, 7), code=0x5F
+            ),
+            SessionTimeoutError,
+        ),
+    ),
+)
+def test_block1_rejects_non_atomic_intermediate_success(response, error_type):
+    session, _requests = _session(lambda request, _number: response(request))
+
+    with pytest.raises(error_type):
+        session.post(["resource"], b"x" * 1025, timeout=0.05)
+
+
+def test_block1_returns_an_intermediate_error_without_sending_more():
+    session, requests = _session(
+        lambda request, _number: _response(request, b"rejected", code=0x80)
+    )
+
+    assert session.post(["resource"], b"x" * 1025) == (0x80, b"rejected")
+    assert len(requests) == 1
+
+
+def test_block1_rejects_continue_as_the_final_response():
+    def respond(request, _number):
+        block = next(value for number, value in request[4] if number == BLOCK1)
+        _num, more, _szx = dtls_session.block_fields(block)
+        return _block1_response(request, code=0x5F if not more else None)
+
+    session, _requests = _session(respond)
+    with pytest.raises(BlockwiseError):
+        session.post(["resource"], b"x" * 1025)
+
+
+def test_block1_refuses_oversized_bodies_before_send():
+    session, requests = _session(lambda request, _number: _block1_response(request))
+
+    with pytest.raises(ValueError, match="524288"):
+        session.post(["resource"], b"x" * (512 * 1024 + 1))
+
+    assert requests == []
+
+
+def test_block1_request_cap_fails_closed_before_the_next_send(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_MAX_BLOCK1_REQUESTS", 1)
+    session, requests = _session(lambda request, _number: _block1_response(request))
+
+    with pytest.raises(BlockwiseError):
+        session.post(["resource"], b"x" * 1025)
+
+    assert len(requests) == 1
+
+
+def test_block1_timeout_and_reader_death_retire_pending_tokens(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.01)
+    session, requests = _session(lambda _request, _number: None)
+    with pytest.raises(SessionTimeoutError):
+        session.post(["resource"], b"x" * 1025, timeout=0.02)
+    assert requests
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+    def stop_reader(_request, _number):
+        session._reader_thread = object()
+        session._reader_running.clear()
+
+    session, _requests = _session(stop_reader)
+    with pytest.raises(SessionClosedError):
+        session.post(["resource"], b"x" * 1025, timeout=1.0)
+    assert session._pending == {}
+    assert session._pending_mids == {}
 
 
 def test_delete_encodes_queries_and_extensions_without_a_payload():

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -5,17 +5,24 @@ from __future__ import annotations
 import pytest
 
 import smartthings_local.protocol.dtls_session as dtls_session
+from smartthings_local.errors import (
+    SessionClosedError,
+    SessionResetError,
+    SessionTimeoutError,
+)
 from smartthings_local.protocol.coap import (
     ACCEPT,
     BLOCK1,
     BLOCK2,
     CONTENT_FORMAT,
+    METHOD_DELETE,
     METHOD_GET,
     METHOD_POST,
     OBSERVE,
     SIZE1,
     SIZE2,
     TYPE_ACK,
+    TYPE_RST,
     URI_PATH,
     URI_QUERY,
     block_value,
@@ -185,6 +192,109 @@ def test_post_retransmission_keeps_query_and_extension_wire_bytes(monkeypatch):
     ]
     assert _VERSION_OPTION in requests[1][4]
     assert _ROUTING_OPTION in requests[1][4]
+
+
+def test_delete_encodes_queries_and_extensions_without_a_payload():
+    session, requests = _session(lambda request, _number: _response(request))
+
+    assert session.delete(
+        ["oic", "sec", "cred"],
+        query=("subjectuuid=peer",),
+        extra_options=(_ROUTING_OPTION,),
+    ) == (0x45, b"ok")
+
+    assert len(requests) == 1
+    _mtype, code, _mid, _token, options, payload = requests[0]
+    assert code == METHOD_DELETE
+    assert payload == b""
+    assert [value for number, value in options if number == URI_QUERY] == [
+        b"subjectuuid=peer"
+    ]
+    assert not [value for number, value in options if number == CONTENT_FORMAT]
+    assert _ROUTING_OPTION in options
+
+
+def test_delete_is_paced_before_send():
+    session, requests = _session(lambda request, _number: _response(request))
+    order = []
+
+    session.pace = lambda: order.append("pace")
+    original_send = session._send_dgram
+
+    def send(datagram):
+        order.append("send")
+        original_send(datagram)
+
+    session._send_dgram = send
+
+    assert session.delete(["resource"]) == (0x45, b"ok")
+    assert order == ["pace", "send"]
+    assert len(requests) == 1
+
+
+def test_delete_timeout_retires_its_pending_exchange():
+    session, requests = _session(lambda _request, _number: None)
+
+    with pytest.raises(SessionTimeoutError):
+        session.delete(["resource"], timeout=0)
+
+    assert len(requests) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_delete_reset_uses_the_shared_mid_registry():
+    def reset(request, _request_number):
+        _mtype, _code, mid, _token, _options, _payload = request
+        return build_coap(TYPE_RST, 0, mid, b"", ())
+
+    session, requests = _session(reset)
+
+    with pytest.raises(SessionResetError):
+        session.delete(["resource"])
+
+    assert len(requests) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_delete_fails_fast_when_the_reader_dies_after_send():
+    session, requests = _session(lambda _request, _number: None)
+    session._reader_thread = object()
+    session._reader_running.set()
+    send = session._send_dgram
+
+    def send_then_stop_reader(datagram):
+        send(datagram)
+        session._reader_running.clear()
+
+    session._send_dgram = send_then_stop_reader
+
+    with pytest.raises(SessionClosedError):
+        session.delete(["resource"])
+
+    assert len(requests) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_delete_keeps_a_response_dispatched_before_reader_teardown():
+    session, requests = _session(lambda request, _number: _response(request))
+    session._reader_thread = object()
+    session._reader_running.set()
+    send = session._send_dgram
+
+    def send_then_stop_reader(datagram):
+        send(datagram)
+        session._reader_running.clear()
+        session._close_pending_requests()
+
+    session._send_dgram = send_then_stop_reader
+
+    assert session.delete(["resource"]) == (0x45, b"ok")
+    assert len(requests) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -1,0 +1,293 @@
+"""Validated URI query and additional CoAP request option tests."""
+
+from __future__ import annotations
+
+import pytest
+
+import smartthings_local.protocol.dtls_session as dtls_session
+from smartthings_local.protocol.coap import (
+    ACCEPT,
+    BLOCK1,
+    BLOCK2,
+    CONTENT_FORMAT,
+    METHOD_GET,
+    METHOD_POST,
+    OBSERVE,
+    SIZE1,
+    SIZE2,
+    TYPE_ACK,
+    URI_PATH,
+    URI_QUERY,
+    block_value,
+    build_coap,
+    parse_coap,
+)
+from smartthings_local.protocol.dtls_session import DtlsCoapSession
+
+_ROUTING_OPTION = (65524, b"\xc0")
+_VERSION_OPTION = (2049, b"\x08\x00")
+
+
+class _NullAuth:
+    def configure_context(self, _context):
+        return None
+
+
+def _session(responder, **session_kwargs):
+    session = DtlsCoapSession(
+        "device.example",
+        5684,
+        auth=_NullAuth(),
+        rate_limit_rps=1_000_000,
+        **session_kwargs,
+    )
+    session.conn = object()
+    requests = []
+
+    def send(datagram):
+        request = parse_coap(datagram)
+        requests.append(request)
+        response = responder(request, len(requests) - 1)
+        if response is not None:
+            session._dispatch_coap(response)
+
+    session._send_dgram = send
+    return session, requests
+
+
+def _response(request, payload=b"ok", *, options=()):
+    _mtype, _code, mid, token, _options, _payload = request
+    return build_coap(TYPE_ACK, 0x45, mid, token, options, payload)
+
+
+def test_get_keeps_query_and_extra_options_on_every_block():
+    def respond(request, request_number):
+        if request_number == 0:
+            return _response(
+                request,
+                b"a" * 1024,
+                options=((BLOCK2, block_value(0, 1, 6)),),
+            )
+        return _response(
+            request,
+            b"done",
+            options=((BLOCK2, block_value(1, 0, 6)),),
+        )
+
+    session, requests = _session(respond)
+    code, payload = session.get(
+        ["oic", "res"],
+        query=("rt=oic.r.doxm", "if=oic.if.baseline"),
+        extra_options=(_VERSION_OPTION, _ROUTING_OPTION),
+    )
+
+    assert code == 0x45
+    assert payload == b"a" * 1024 + b"done"
+    assert len(requests) == 2
+    assert all(request[1] == METHOD_GET for request in requests)
+    for request in requests:
+        options = request[4]
+        assert [value for number, value in options if number == URI_PATH] == [
+            b"oic",
+            b"res",
+        ]
+        assert [value for number, value in options if number == URI_QUERY] == [
+            b"rt=oic.r.doxm",
+            b"if=oic.if.baseline",
+        ]
+        assert _VERSION_OPTION in options
+        assert _ROUTING_OPTION in options
+    assert not [value for number, value in requests[0][4] if number == BLOCK2]
+    assert [value for number, value in requests[1][4] if number == BLOCK2] == [
+        block_value(1, 0, 6)
+    ]
+
+
+def test_get_retransmission_keeps_query_and_extension_wire_bytes(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.001)
+
+    def respond(request, request_number):
+        return _response(request) if request_number == 1 else None
+
+    session, requests = _session(respond)
+    datagrams = []
+    send = session._send_dgram
+
+    def record_and_send(datagram):
+        datagrams.append(datagram)
+        send(datagram)
+
+    session._send_dgram = record_and_send
+
+    assert session.get(
+        ["oic", "res"],
+        timeout=1.0,
+        query=("if=oic.if.baseline",),
+        extra_options=(_VERSION_OPTION, _ROUTING_OPTION),
+    ) == (0x45, b"ok")
+
+    assert len(requests) == 2
+    assert datagrams[0] == datagrams[1]
+    assert _VERSION_OPTION in requests[1][4]
+    assert _ROUTING_OPTION in requests[1][4]
+
+
+def test_post_encodes_repeated_queries_and_ordered_extra_options():
+    session, requests = _session(lambda request, _number: _response(request))
+
+    assert session.post(
+        ["mode", "vs", "0"],
+        b"payload",
+        query=("if=oic.if.a", "x.example=value"),
+        extra_options=(_VERSION_OPTION, _ROUTING_OPTION),
+    ) == (0x45, b"ok")
+
+    assert len(requests) == 1
+    _mtype, code, _mid, _token, options, payload = requests[0]
+    assert code == METHOD_POST
+    assert payload == b"payload"
+    assert [value for number, value in options if number == URI_QUERY] == [
+        b"if=oic.if.a",
+        b"x.example=value",
+    ]
+    assert _VERSION_OPTION in options
+    assert _ROUTING_OPTION in options
+
+
+def test_post_retransmission_keeps_query_and_extension_wire_bytes(monkeypatch):
+    monkeypatch.setattr(dtls_session, "_WRITE_ACK_TIMEOUT", 0.001)
+
+    def respond(request, request_number):
+        return _response(request) if request_number == 1 else None
+
+    session, requests = _session(respond, write_max_attempts=2)
+    datagrams = []
+    send = session._send_dgram
+
+    def record_and_send(datagram):
+        datagrams.append(datagram)
+        send(datagram)
+
+    session._send_dgram = record_and_send
+
+    assert session.post(
+        ["mode", "vs", "0"],
+        b"payload",
+        timeout=1.0,
+        query=("if=oic.if.a",),
+        extra_options=(_VERSION_OPTION, _ROUTING_OPTION),
+    ) == (0x45, b"ok")
+
+    assert len(requests) == 2
+    assert datagrams[0] == datagrams[1]
+    assert [value for number, value in requests[1][4] if number == URI_QUERY] == [
+        b"if=oic.if.a"
+    ]
+    assert _VERSION_OPTION in requests[1][4]
+    assert _ROUTING_OPTION in requests[1][4]
+
+
+@pytest.mark.parametrize(
+    ("operation", "error_type"),
+    (
+        (lambda session: session.get("oic"), TypeError),
+        (lambda session: session.get([1]), TypeError),
+        (lambda session: session.get(["x" * 1025]), ValueError),
+        (lambda session: session.get(["\ud800"]), ValueError),
+        (lambda session: session.get(["oic"], query="x=y"), TypeError),
+        (lambda session: session.get(["oic"], query=(1,)), TypeError),
+        (lambda session: session.get(["oic"], query=("",)), ValueError),
+        (lambda session: session.get(["oic"], query=("x" * 1025,)), ValueError),
+        (
+            lambda session: session.get(["oic"], query=("x=y",) * 33),
+            ValueError,
+        ),
+        (lambda session: session.post(["oic"], bytearray(b"x")), TypeError),
+        (
+            lambda session: session.get(["oic"], extra_options=(("2049", b"x"),)),
+            TypeError,
+        ),
+        (
+            lambda session: session.get(
+                ["oic"], extra_options=((2049, bytearray(b"x")),)
+            ),
+            TypeError,
+        ),
+        (
+            lambda session: session.get(["oic"], extra_options=((2049, b"x" * 1025),)),
+            ValueError,
+        ),
+        (
+            lambda session: session.get(
+                ["oic"], extra_options=((65524, b"x"), (2049, b"y"))
+            ),
+            ValueError,
+        ),
+        (
+            lambda session: session.get(["oic"], extra_options=((0, b"x"),)),
+            ValueError,
+        ),
+        (
+            lambda session: session.get(["oic"], extra_options=((65536, b"x"),)),
+            ValueError,
+        ),
+        (
+            lambda session: session.get(
+                ["oic"], extra_options=tuple((2049, b"x") for _ in range(33))
+            ),
+            ValueError,
+        ),
+    ),
+)
+def test_invalid_request_options_fail_before_send(operation, error_type):
+    session, requests = _session(lambda request, _number: _response(request))
+
+    with pytest.raises(error_type):
+        operation(session)
+
+    assert requests == []
+
+
+@pytest.mark.parametrize(
+    "option_number",
+    (
+        URI_PATH,
+        URI_QUERY,
+        OBSERVE,
+        CONTENT_FORMAT,
+        ACCEPT,
+        BLOCK2,
+        BLOCK1,
+        SIZE2,
+        SIZE1,
+    ),
+)
+def test_transport_managed_options_cannot_be_overridden(option_number):
+    session, requests = _session(lambda request, _number: _response(request))
+
+    with pytest.raises(ValueError, match="managed"):
+        session.get(["oic"], extra_options=((option_number, b"x"),))
+
+    assert requests == []
+
+
+def test_repeated_additional_option_numbers_preserve_order():
+    session, requests = _session(lambda request, _number: _response(request))
+    repeated = ((2049, b"a"), (2049, b"b"))
+
+    session.get(["oic"], extra_options=repeated)
+
+    assert [item for item in requests[0][4] if item[0] == 2049] == list(repeated)
+
+
+def test_validation_errors_do_not_echo_option_values():
+    session, _requests = _session(lambda request, _number: _response(request))
+    private_value = b"credential-value"
+
+    with pytest.raises(ValueError) as error:
+        session.get(
+            ["oic"],
+            extra_options=((65524, private_value), (2049, b"out-of-order")),
+        )
+
+    assert private_value.decode() not in str(error.value)


### PR DESCRIPTION
## Summary

- keep POST bodies through 1024 bytes on the existing #54 single-frame attempt loop
- route larger bodies into Block1 before allocating an ordinary POST exchange
- upload larger bodies with one token, one shared-registry MID per logical block, byte-identical per-block retransmission, and Size1 on the first block
- honor a server-requested smaller block size by byte offset
- keep URI queries and extension options on every block
- reject incomplete, contradictory, oversized, or unbounded transfers with typed errors

## Why

This implements the Block1 path used by my working Home Assistant integration for the local washer/dryer connection flow. The transport keeps each block as its own confirmable CoAP exchange instead of relying on one oversized request being reconstructed across DTLS application-data records.

I do not currently have a shareable A/B capture of the same oversized body failing without Block1 and succeeding with Block1. QuiteYellow offered to run that comparison on a dryer and oven in the review; that remains the hardware gate before merge.

This PR adds only the transport primitive. The credential or ownership payload that a caller may send, and any decision to perform that write, remain outside this change.

## Current base and retry behavior

This branch is restacked on #49 and the merged #54/#57/#58 substrate. Bodies through 1024 bytes still use the #54 ordinary POST loop unchanged. A larger body branches before an ordinary token, MID, or pending exchange is allocated.

Each Block1 chunk registers once in the shared token/MID registry, reuses one encoded datagram across its bounded retries, stops retransmitting after an empty ACK, surfaces RST by MID, and waits through `_wait_live`. The Block1 retry count is independent of `write_max_attempts`.

The Block1-only commit is `1f5b959`.

## Stack / merge order

1. #48: validated query and extension options
2. #49: DELETE
3. #50 (this PR): bounded Block1 POST uploads

Merge #50 after #49.

## Validation

- 490 SmartThings-Local tests against this exact head
- all 1,730 LocalThings tests at `b5e25d7` against this exact source tree
- exact and partial boundaries, size downshift, stale responses, byte-identical retransmission, response-during-pace, empty ACK, RST, reader teardown, per-attempt deadlines, builder-failure cleanup, request cap, and payload cap
- current Home Assistant request behavior compared against the working integration; its 55 focused transport/resilience tests pass
- wheel and sdist content checks plus isolated install/import smoke tests
- bytecode compilation and share-safety checks
- all eight GitHub jobs pass on this exact head, including Python 3.11-3.14, dependency-floor/latest, package, and share safety