### PR TITLE
fix(protocol): reuse one MID across block retransmissions

### DIFF
--- a/smartthings_local/errors.py
+++ b/smartthings_local/errors.py
@@ -10,6 +10,8 @@ __all__ = [
     'ProbeError',
     'SessionClosedError',
     'SessionError',
+    'SessionIdentifierError',
+    'SessionResetError',
     'SessionTimeoutError',
     'SmartThingsLocalError',
 ]
@@ -80,6 +82,30 @@ class SessionClosedError(SessionError):
 
     code = 'session_closed'
     message = 'session is closed'
+
+
+class SessionResetError(SessionError):
+    """The peer rejected an exchange with a CoAP RST.
+
+    Distinct from a closed session: the transport is still up and every
+    other exchange on it is unaffected. Only the message the RST names has
+    been refused.
+    """
+
+    code = 'session_reset'
+    message = 'peer reset the exchange'
+
+
+class SessionIdentifierError(SessionError):
+    """No free Message ID or token was available for a new exchange.
+
+    Every identifier in the space is held by an exchange that has not yet
+    completed, which in practice means requests are leaking rather than
+    that the session is genuinely saturated.
+    """
+
+    code = 'session_identifier'
+    message = 'no free message identifier for a new exchange'
 
 
 class MalformedMessageError(SmartThingsLocalError, ValueError):

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -40,6 +40,8 @@ from ..errors import (
     EndpointError,
     SessionClosedError,
     SessionError,
+    SessionIdentifierError,
+    SessionResetError,
     SessionTimeoutError,
 )
 from .coap import (
@@ -528,12 +530,19 @@ class DtlsCoapSession:
     # ---- send / receive plumbing -------------------------------------
 
     def _next_available_mid_locked(self):
-        """Return the next MID that is not owned by a live request."""
-        for _ in range(0x10000):
+        """Return the next MID that is not owned by a live request.
+
+        Probing one more candidate than there are live exchanges is enough
+        by the pigeonhole principle: the candidates are consecutive and so
+        distinct, and at most len(_pending_mids) of them can be taken. In
+        practice that means a single probe, instead of a walk over all
+        65,536 identifiers to discover what the dict size already implied.
+        """
+        for _ in range(min(len(self._pending_mids) + 1, 0x10000)):
             self._mid = (self._mid + 1) & 0xFFFF
             if self._mid not in self._pending_mids:
                 return self._mid
-        raise SessionError()
+        raise SessionIdentifierError()
 
     def _next_mid(self):
         with self._state_lock:
@@ -543,7 +552,7 @@ class DtlsCoapSession:
         """Atomically allocate a MID and index one request by MID and token."""
         with self._state_lock:
             if tok in self._pending:
-                raise SessionError()
+                raise SessionIdentifierError()
             mid = self._next_available_mid_locked()
             pending = (ev, container)
             exchange = _MidExchange(pending)
@@ -761,7 +770,7 @@ class DtlsCoapSession:
                 if exchange is not None:
                     ev, container = exchange.pending
                     if 'code' not in container and 'err' not in container:
-                        container['err'] = SessionError()
+                        container['err'] = SessionResetError()
             if exchange is not None:
                 ev.set()
             return
@@ -1021,24 +1030,30 @@ class DtlsCoapSession:
         A response whose Block2 NUM is not the one we asked for is a
         retransmit of an earlier block, not the next one. Concatenating
         it would corrupt the buffer, so keep waiting on the same
-        attempt budget instead."""
-        for attempt in range(_BLOCK_MAX_ATTEMPTS):
-            ev = threading.Event()
-            container = {}
-            mid, exchange = self._register_pending_request(tok, ev, container)
-            try:
+        attempt budget instead.
+
+        Every attempt sends the byte-identical datagram, so the exchange is
+        registered once outside the loop. RFC 7252 §4.2 defines a
+        retransmission as the same message, and a fresh MID per attempt
+        instead presents each retry to the appliance as a brand-new
+        request that it may answer separately."""
+        ev = threading.Event()
+        container = {}
+        mid, exchange = self._register_pending_request(tok, ev, container)
+        opts = [(URI_PATH, s.encode()) for s in path_segs]
+        for q in query:
+            opts.append((URI_QUERY, q.encode()))
+        opts.append((ACCEPT, CF_CBOR))
+        if num > 0:
+            opts.append((BLOCK2, block_value(num, 0, szx)))
+        datagram = build_coap(TYPE_CON, METHOD_GET, mid, tok, opts)
+        try:
+            for attempt in range(_BLOCK_MAX_ATTEMPTS):
                 # Close the reader-death registration race: after this request
                 # is visible to reader-finally, recheck that the reader still
                 # owns the session before sending.
                 self._check_live()
-                opts = [(URI_PATH, s.encode()) for s in path_segs]
-                for q in query:
-                    opts.append((URI_QUERY, q.encode()))
-                opts.append((ACCEPT, CF_CBOR))
-                if num > 0:
-                    opts.append((BLOCK2, block_value(num, 0, szx)))
-                self._send_dgram(
-                    build_coap(TYPE_CON, METHOD_GET, mid, tok, opts))
+                self._send_dgram(datagram)
                 while True:
                     with self._state_lock:
                         if ('err' in container
@@ -1080,8 +1095,8 @@ class DtlsCoapSession:
                     self.host, '/'.join(path_segs), num,
                     attempt + 1, _BLOCK_MAX_ATTEMPTS,
                 )
-            finally:
-                self._unregister_pending_request(tok, mid, exchange)
+        finally:
+            self._unregister_pending_request(tok, mid, exchange)
         raise SessionTimeoutError()
 
     def _wait_for_block(self, ev, per_wait):

--- a/tests/test_dtls_session_mid_registry.py
+++ b/tests/test_dtls_session_mid_registry.py
@@ -10,6 +10,7 @@ from smartthings_local.errors import (
     EndpointError,
     SessionClosedError,
     SessionError,
+    SessionResetError,
     SessionTimeoutError,
 )
 from smartthings_local.protocol import dtls_session
@@ -139,7 +140,9 @@ def test_matching_bare_rst_fails_request(operation):
     with pytest.raises(SessionError) as raised:
         _request(session, operation)
 
-    assert type(raised.value) is SessionError
+    # A RST refuses one exchange while the transport stays up, so it is its
+    # own type rather than the generic session failure.
+    assert type(raised.value) is SessionResetError
     assert session._pending == {}
     assert session._pending_mids == {}
 

--- a/tests/test_mid_registry_retransmission.py
+++ b/tests/test_mid_registry_retransmission.py
@@ -1,0 +1,140 @@
+"""Follow-ups to the shared MID registry (#57).
+
+Covers the read path reusing one MID across retransmissions, and the two
+identifier-allocation failures now carrying their own type.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from smartthings_local.errors import (
+    SessionIdentifierError,
+    SessionTimeoutError,
+)
+from smartthings_local.protocol import dtls_session
+from smartthings_local.protocol.coap import (
+    METHOD_GET,
+    TYPE_CON,
+    build_coap,
+    parse_coap,
+)
+from smartthings_local.protocol.dtls_session import DtlsCoapSession
+
+
+class _NullAuth:
+    def configure_context(self, _context):
+        return None
+
+
+def _session():
+    session = DtlsCoapSession(
+        "device.example",
+        5684,
+        auth=_NullAuth(),
+        rate_limit_rps=1_000_000,
+    )
+    session.conn = object()
+    return session
+
+
+def test_get_retransmission_reuses_one_mid_and_datagram(monkeypatch):
+    """RFC 7252 §4.2: a retransmission is the same message.
+
+    A fresh MID per attempt presents each retry to the appliance as a new
+    request it may answer separately.
+    """
+    session = _session()
+    sent = []
+
+    monkeypatch.setattr(dtls_session, "_BLOCK_ACK_TIMEOUT", 0.01)
+
+    def send(datagram):
+        # Skip the bare ACK the session sends back for the device's own CON
+        # notification; only the GET requests are under test here.
+        if parse_coap(datagram)[1] == METHOD_GET:
+            sent.append(datagram)
+
+    session._send_dgram = send
+
+    # Answer only once the third attempt is on the wire, so two full
+    # retransmissions have to happen first.
+    def wait_for_block(_event, _timeout):
+        if len(sent) < 3:
+            return False
+        _mtype, _code, mid, token, _options, _payload = parse_coap(sent[-1])
+        session._dispatch_coap(
+            build_coap(TYPE_CON, 0x45, mid + 1, token, [], b"ok")
+        )
+        return True
+
+    session._wait_for_block = wait_for_block
+
+    assert session.get(["device", "0"], timeout=5.0) == (0x45, b"ok")
+
+    assert len(sent) == 3
+    assert len(set(sent)) == 1, "retransmissions must be byte-identical"
+    mids = {parse_coap(datagram)[2] for datagram in sent}
+    assert len(mids) == 1
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_exhausted_attempts_still_release_the_single_registration():
+    session = _session()
+    session._send_dgram = lambda _datagram: None
+    session._wait_for_block = lambda _event, _timeout: False
+
+    with pytest.raises(SessionTimeoutError):
+        session.get(["device", "0"], timeout=0.05)
+
+    assert session._pending == {}
+    assert session._pending_mids == {}
+
+
+def test_token_already_in_flight_is_its_own_error():
+    session = _session()
+    event = threading.Event()
+    container = {}
+    token = b"\x01\x02"
+    session._register_pending_request(token, event, container)
+
+    with pytest.raises(SessionIdentifierError):
+        session._register_pending_request(token, threading.Event(), {})
+
+
+def test_mid_allocation_probes_only_past_the_live_exchanges():
+    """Pigeonhole: one more candidate than live exchanges always suffices.
+
+    The old walk went through all 65,536 identifiers to discover what the
+    registry size already implied.
+    """
+    session = _session()
+    probes = []
+    real_pending_mids = session._pending_mids
+
+    class _CountingMids(dict):
+        def __contains__(self, key):
+            probes.append(key)
+            return dict.__contains__(self, key)
+
+    counting = _CountingMids(real_pending_mids)
+    for offset in range(1, 4):
+        counting[(session._mid + offset) & 0xFFFF] = object()
+    session._pending_mids = counting
+
+    mid = session._next_mid()
+
+    assert mid == (session._mid) & 0xFFFF
+    assert len(probes) == 4, "three live exchanges, so at most four probes"
+    assert mid not in counting
+
+
+def test_mid_allocation_raises_when_every_identifier_is_live():
+    session = _session()
+    session._pending_mids = {mid: object() for mid in range(0x10000)}
+
+    with pytest.raises(SessionIdentifierError):
+        session._next_mid()


### PR DESCRIPTION
## Summary

Three follow-ups on top of #57, all named in its review. None of them are regressions from that PR.

## The read path now retransmits one MID

`_exchange_block` registered a new exchange on every attempt, so an unacknowledged retry went out under a fresh Message ID. RFC 7252 §4.2 defines a retransmission as the same message; a new ID presents each retry to the appliance as a separate request that it may answer more than once. The Block2 NUM check discarded the surplus answer, which masked the effect without removing the cause.

Registration and the datagram now happen once, outside the attempt loop, and each attempt sends identical bytes. @mbillow described this in the body of #54 and it predates #57.

Retransmission pacing is untouched, since #54 owns that policy.

## Two allocation failures have their own types

A CoAP RST raises `SessionResetError`. It refuses one exchange while the transport stays up, which is a different situation from a closed session.

Both "no free Message ID" and "this token is already in flight" raise `SessionIdentifierError`.

Previously all three surfaced as a bare `SessionError()`, which #23 added the typed hierarchy to avoid. `tests/test_dtls_session_mid_registry.py` pinned the old exact type, so that assertion moves with the behaviour.

## MID allocation stops walking the whole space

`_next_available_mid_locked` probed all 65,536 identifiers before raising. Candidates are consecutive and so distinct, which means one more candidate than there are live exchanges always finds a free one. That is a single probe in normal operation, and it only fails when every identifier is held.

## Validation

- `pytest tests/`: 325 passed, 5 of them new
- Ruff clean on the added test module and on `errors.py`
- `git diff --check` clean

## Sequencing

#56 asks everyone to hold their rebases until this is in, so that #36, #54 and #48, #49, #50 each rebase once. Merging this releases them.

