### PR TITLE
refactor(mqtt): drop the redundant sleep between OBSERVE registrations

### DIFF
--- a/mqtt_demo/bridge.py
+++ b/mqtt_demo/bridge.py
@@ -386,7 +386,6 @@ class PushBridge:
     def _run_session_inner(self, sess):
         for path in self.descriptor.observe_paths:
             sess.subscribe(path)
-            time.sleep(0.05)
 
         # Inline seed so the publish gate opens before the scheduler's
         # first tick. The scheduler's sweep tier will refresh /device/0


### PR DESCRIPTION
`_run_session_inner` slept 50ms after every `subscribe()` call. `subscribe()` opens with `self.pace()`, which withholds the send until `_min_req_interval` has passed since the last datagram, and the default rate limit is 5 req/s. The sleep was always shorter than the wait that followed it, so no registration ever left the host at a different time because of it.

Noted on #51 and #53.

Deployed to the reference bridge (one dryer, one oven) and soaked. Discarding the window that contains the connect, five 60-second windows on each: dryer 95-96 ok, oven 220-229 ok, no errors, no ping failures and no timeouts on either. Those counts sit inside the pre-change baseline of 94-96 and 222-229. The dryer seeded without the DTLS listener stall a container recreate sometimes causes.

Latency in the steady-state windows also matches baseline (dryer p_max 256-272ms against 221-283ms, oven 2011-2346ms against 1838-1980ms). The two windows containing a link sweep ran above their baseline counterparts, dryer 1151ms against 913ms and oven 3447ms against 2635ms, with `slow` counts unchanged. Removing a delay cannot add latency, so I read those two as device-side sweep variance. The numbers are here either way.

`mqtt_demo/` is outside the distributed package, so this does not reach the wheel.
