### PR TITLE
fix(protocol): return only the error body when a Block2 transfer fails

### DIFF
--- a/smartthings_local/protocol/coap.py
+++ b/smartthings_local/protocol/coap.py
@@ -490,15 +490,19 @@ class Block2Accumulator:
         if message.code == 0:
             raise BlockwiseError()
 
-        # A non-success response terminates the logical GET immediately while
-        # preserving the connected-session contract of returning bytes already
-        # accumulated before and in the error response.
+        # A non-success response terminates the logical GET. Its body is a
+        # diagnostic in the server's own format rather than a continuation of
+        # the representation, so it replaces whatever blocks arrived instead
+        # of extending them: get() returns (code, payload) with no boundary
+        # marker between the two, so concatenating leaves the caller one
+        # buffer holding two content types and no way to split it. Callers
+        # gate on 2.05 before decoding, so the accumulated bytes have no
+        # reader once the code is not 2.xx.
         if message.code >> 5 != 2:
-            if len(self._payload) + len(message.payload) > \
-                    self._max_payload_bytes:
+            if len(message.payload) > self._max_payload_bytes:
                 raise BlockwiseError()
             self._code = message.code
-            self._payload.extend(message.payload)
+            self._payload = bytearray(message.payload)
             self._blocks_received += 1
             self._complete = True
             return BLOCK2_COMPLETE

--- a/tests/test_coap_wire.py
+++ b/tests/test_coap_wire.py
@@ -434,7 +434,7 @@ def test_block2_continuation_requires_an_explicit_block2_option():
         ))
 
 
-def test_mid_transfer_error_preserves_connected_session_contract_by_default():
+def test_mid_transfer_error_replaces_the_partial_representation():
     error = _message(
         code=0x80,
         payload=b'error',
@@ -450,7 +450,20 @@ def test_mid_transfer_error_preserves_connected_session_contract_by_default():
     ))
     assert accumulator.add_response(error) == BLOCK2_COMPLETE
     assert accumulator.code == 0x80
-    assert accumulator.payload == b'a' * 16 + b'error'
+    assert accumulator.payload == b'error'
+
+
+def test_error_before_any_block_returns_the_diagnostic_body():
+    accumulator = Block2Accumulator(b'token')
+    assert accumulator.add_response(_message(
+        code=0x80,
+        payload=b'error',
+        include_block=False,
+        etag=None,
+        content_format=None,
+    )) == BLOCK2_COMPLETE
+    assert accumulator.code == 0x80
+    assert accumulator.payload == b'error'
 
 
 def test_block2_accumulator_enforces_exact_block_and_payload_bounds():
@@ -493,6 +506,34 @@ def test_block2_accumulator_enforces_exact_block_and_payload_bounds():
     too_large = Block2Accumulator(b'token', max_payload_bytes=16)
     with pytest.raises(BlockwiseError):
         too_large.add_response(_message(
+            payload=b'x' * 17,
+            include_block=False,
+            etag=None,
+            content_format=None,
+        ))
+
+    # An error body is bounded on its own length, since it replaces the
+    # accumulated blocks rather than extending them: a diagnostic that fits
+    # is accepted however many bytes arrived before it.
+    after_blocks = Block2Accumulator(b'token', max_payload_bytes=16)
+    after_blocks.add_response(_message(
+        number=0,
+        more=True,
+        payload=b'a' * 16,
+    ))
+    assert after_blocks.add_response(_message(
+        code=0x80,
+        payload=b'x' * 16,
+        include_block=False,
+        etag=None,
+        content_format=None,
+    )) == BLOCK2_COMPLETE
+    assert after_blocks.payload == b'x' * 16
+
+    oversized_error = Block2Accumulator(b'token', max_payload_bytes=16)
+    with pytest.raises(BlockwiseError):
+        oversized_error.add_response(_message(
+            code=0x80,
             payload=b'x' * 17,
             include_block=False,
             etag=None,

--- a/tests/test_dtls_session_reader_death.py
+++ b/tests/test_dtls_session_reader_death.py
@@ -500,7 +500,7 @@ def test_empty_ack_survives_stale_block_until_separate_response(
     assert sess._pending_mids == {}
 
 
-def test_get_preserves_mid_transfer_error_payload_contract():
+def test_get_returns_only_the_error_body_when_a_transfer_fails_mid_way():
     sess = _make_session()
 
     def respond(datagram):
@@ -527,7 +527,7 @@ def test_get_preserves_mid_transfer_error_payload_contract():
 
     sess._send_dgram = respond
     sess.pace = lambda: None
-    assert sess.get(['oic', 'res']) == (0x80, b'a' * 16 + b'error')
+    assert sess.get(['oic', 'res']) == (0x80, b'error')
 
 
 @pytest.mark.parametrize('method', ('get', 'post'))


### PR DESCRIPTION
Follow-up to #36, on one contract detail I raised in review and then took myself.

`Block2Accumulator.add_response` extended the accumulated representation with a non-success response's body before completing. A 4.xx or 5.xx arriving mid-transfer produced one buffer holding assembled blocks followed by a diagnostic in the server's own format, and `get()` returns `(code, payload)` with no boundary marker between them, so the caller had no way to split it.

The error body now replaces the partial representation.

## Nothing observed the old behaviour

Every `get()` consumer gates on the code before touching the payload: `bridge.py:253`, `:486` and `:516` all check for 2.05 first. Once the code is not 2.xx the accumulated bytes had no reader.

## The first-block case is unchanged

Where the error arrives before any block, #36 already returned the diagnostic body where the pre-#36 path returned an empty buffer. That was an improvement and it stays. This change makes it the behaviour in every case.

## Bounds

The payload bound moves from the combined length to the error body's own, since the buffer now only ever holds one or the other. An error body that fits is accepted however many bytes arrived before it; an oversized one still raises `BlockwiseError`.

## Tests

Two tests pinned the old contract and both are updated, one at the accumulator and one driving it end to end through `get()`:

- `test_mid_transfer_error_replaces_the_partial_representation`
- `test_get_returns_only_the_error_body_when_a_transfer_fails_mid_way`

Two added:

- `test_error_before_any_block_returns_the_diagnostic_body`, so the case #36 improved cannot quietly revert to the pre-#36 empty buffer
- an error-body bound case inside `test_block2_accumulator_enforces_exact_block_and_payload_bounds`, covering the loosened check in both directions

403 pass. Ruff clean on all three touched files.

## Hardware

Not separately validated. #36 itself ran on the reference bridge against one dryer and one oven across a container recreate, and this path needs a mid-transfer 4.xx from the appliance to fire, which neither device produced during that run.
