### PR TITLE
fix(tools): stop reading scope operators as leaked IPv6 addresses

### DIFF
--- a/tests/test_share_safety.py
+++ b/tests/test_share_safety.py
@@ -156,3 +156,29 @@ def test_committed_scan_ignores_unchanged_findings_but_checks_added_lines(
     assert check_share_safety.check_changed(base) == [
         check_share_safety.Finding("candidate.txt", 3, "NON_DOCUMENTATION_IPV4")
     ]
+
+
+def test_scope_operators_are_not_read_as_ipv6_addresses():
+    """`Foo::bar` matches the IPv6 pattern and parses as an address in
+    ::/8. Reserved blocks are not assignable to a host, so an address in
+    one cannot be the leak this rule exists to catch."""
+    colons = 2 * chr(58)
+    for text in (
+        "the leaf's `TbsCertificate" + colons + "signature_alg` is unparseable",
+        "see `std" + colons + "vector` and `Face" + colons + "expressRequest`",
+        "0" + colons + "1 is the discard prefix",
+    ):
+        assert check_share_safety.scan_text("doc.md", text) == []
+
+
+def test_host_assignable_ipv6_addresses_are_still_flagged():
+    colons = 2 * chr(58)
+    for text in (
+        "fe80" + colons + "1",          # link-local
+        "fd00" + colons + "1",          # unique-local
+        "2400" + chr(58) + "cb00" + colons + "1",  # global unicast
+    ):
+        findings = check_share_safety.scan_text("doc.md", text)
+        assert [finding.rule_id for finding in findings] == [
+            "NON_DOCUMENTATION_IPV6"
+        ], text

--- a/tools/check_share_safety.py
+++ b/tools/check_share_safety.py
@@ -128,7 +128,17 @@ def _safe_ipv4(value: str) -> bool:
 def _safe_ipv6(value: str) -> bool:
     address = ipaddress.ip_address(value.strip("[]").split("%", 1)[0])
     return (
-        address.is_loopback or address.is_unspecified or address in DOCUMENTATION_IPV6
+        address.is_loopback
+        or address.is_unspecified
+        or address in DOCUMENTATION_IPV6
+        # An address in an IETF-reserved block is not assignable to a host,
+        # so it cannot be the leak this rule exists to catch. Excluding them
+        # also clears a false positive on C++ and Rust scope operators: a
+        # scope operator preceded by a hex letter matches IPV6_RE, parses as
+        # an address in the all-zero reserved block, and is nobody's device.
+        # Global unicast, link-local and unique-local all sit outside the
+        # reserved set and stay flagged; see the tests for each.
+        or address.is_reserved
     )
 
 


### PR DESCRIPTION
`check_share_safety.py` reads a C++ or Rust scope operator as a leaked IPv6 address and fails the build.

Surfaced on #60, where the line

```
- the leaf's `TbsCertificate::signature_alg` is one `cryptography` refuses to
```

reports `NON_DOCUMENTATION_IPV6`. `IPV6_RE` allows empty hex groups, so it matches `e::` out of `...ficate::signature`, and `ipaddress` parses that as a valid address in the all-zero reserved block. Any scope operator preceded by a hex letter does it.

## The fix

`_safe_ipv6` now also accepts an address in an IETF-reserved block. Such an address is not assignable to a host, so it cannot be the leak the rule exists to catch. Global unicast, link-local and unique-local all sit outside the reserved set and stay flagged, which is the whole population of real leaks: a device on somebody's LAN has one of those three.

Tightening the regex was the alternative and it is worse. The obvious tightening, requiring a substantial first group, drops link-local addresses, which are exactly what leaks out of a capture.

## Residual gap

A NAT64-prefixed address written entirely in hex now passes. The dotted-tail form of the same address is still caught by `IPV4_RE` on the same line. Contriving the hex form as an exfiltration route seems less likely than the false positive it costs.

## Tests

Two added: scope operators in the shapes that appear in these docs produce no findings, and link-local, unique-local and global unicast each still report `NON_DOCUMENTATION_IPV6`. Both follow the file's existing convention of splitting literals so the test file does not trip the checker scanning it.

405 pass, and the checker scans its own source and tests clean. #60's document scans clean with no change to it.
