### PR TITLE
feat(protocol): add bounded plaintext OCF resource reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,45 @@ Returned ports are unauthenticated candidates, not DTLS endpoints; directory
 parsing, DTLS liveness, and authenticated device identity remain separate
 checks.
 
+### Bounded plaintext OCF resource reads
+
+Once the public request port is known, callers can read an absolute OCF href
+without reimplementing the source-port and Block2 handling used by directory
+discovery:
+
+```python
+import cbor2
+
+from smartthings_local.protocol.ocf_discovery import (
+    read_plaintext_ocf_resource,
+)
+
+resource = read_plaintext_ocf_resource(
+    "192.0.2.20",
+    "/oic/d",
+    port=5683,
+)
+if resource.successful:
+    device = cbor2.loads(resource.payload)
+elif resource.complete:
+    print(f"appliance returned CoAP code {resource.code:#04x}")
+else:
+    print(resource.error_code)
+```
+
+The reader sends a read-only NON GET and returns the raw body instead of
+assuming one representation shape. It keeps one token across Block2, pins a
+different response source port after the first correlated reply, uses a fresh
+message ID for each request attempt, and applies one deadline plus the same
+32-block, 64-KiB, and datagram bounds as directory discovery. Successful
+representations must either omit Content-Format or identify OCF/CoAP CBOR.
+
+A complete 4.xx or 5.xx response is returned with its code and body rather
+than converted into a transport failure. Public resources vary by firmware:
+reaching a plaintext endpoint does not authenticate the appliance or grant
+access to protected appliance data. `content_format` and `size2` describe
+successful representations; they are `None` for a non-success diagnostic body.
+
 For a full worked integration, the higher-level `smartthings_local.ocf` layer (`StateCache`, `PollScheduler`, `KeepaliveTask`, `ObserveRefreshTask`) coordinates tiered polling and OBSERVE on top of a session. The MQTT bridge demo below wires all of it together.
 
 ### What the demo bridge gives you

--- a/smartthings_local/protocol/ocf_discovery.py
+++ b/smartthings_local/protocol/ocf_discovery.py
@@ -1,12 +1,14 @@
-"""Bounded discovery of OCF-advertised secure UDP ports.
+"""Bounded plaintext OCF reads and advertised secure-port discovery.
 
-This known-host API requires the target's public CoAP request port to already
+These known-host APIs require the target's public CoAP request port to already
 be known. UDP 5683 is a convenience default, not a port-discovery mechanism;
 callers must locate and explicitly pass a different public port when the
-target does not listen there. A response may still originate from another
-source port, so this module uses unconnected UDP sockets, validates the
-resolved target address and CoAP token, then pins the first valid response
-endpoint for the remainder of each bounded Block2 transfer.
+target does not listen there. ``read_plaintext_ocf_resource`` returns the raw
+representation and response code for one absolute href. A response may still
+originate from another source port, so this module uses unconnected UDP
+sockets, validates the resolved target address and CoAP token, then pins the
+first valid response endpoint for the remainder of each bounded Block2
+transfer.
 
 Discovery first reads the unfiltered ``/oic/res`` directory and accepts only
 secure ``eps`` entries bound to that response source. If the representation
@@ -49,7 +51,9 @@ from .endpoint import ResolvedUdpEndpoint, resolve_udp_endpoints
 
 __all__ = [
     'OcfSecurePortDiscoveryResult',
+    'PlaintextOcfResourceResult',
     'discover_ocf_secure_ports',
+    'read_plaintext_ocf_resource',
 ]
 
 _DISCOVERY_PORT = 5683
@@ -60,6 +64,8 @@ _MAX_DATAGRAM_BYTES = 8192
 _MAX_PAYLOAD_BYTES = 65536
 _MAX_LINKS = 256
 _MAX_ENDPOINT_URIS_PER_LINK = 32
+_MAX_REQUEST_OPTION_BYTES = 1024
+_MAX_REQUEST_OPTION_COUNT = 32
 _OCF_CBOR_CONTENT_FORMAT = 10000
 _CONTENT = 0x45
 _PRIMARY_QUERY = ()
@@ -79,6 +85,48 @@ _PORTS_UNTRUSTED = 'untrusted'
 _ENDPOINT_IGNORE = 'ignore'
 _ENDPOINT_MATCH = 'match'
 _ENDPOINT_UNTRUSTED = 'untrusted'
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PlaintextOcfResourceResult:
+    """Redacted outcome of one bounded plaintext OCF resource read.
+
+    A complete non-success response is still a valid result: inspect
+    ``successful`` before decoding ``payload``. ``content_format`` and
+    ``size2`` describe a successful representation and remain ``None`` for a
+    non-success diagnostic body. The custom representation deliberately omits
+    the payload, target, resource path, and wire data.
+    """
+
+    code: int | None
+    payload: bytes
+    blocks_received: int
+    content_format: int | None
+    size2: int | None
+    attempts: int
+    response_received: bool
+    error_code: str | None = None
+
+    @property
+    def complete(self):
+        """Return whether a complete correlated response was received."""
+        return self.code is not None and self.error_code is None
+
+    @property
+    def successful(self):
+        """Return whether the complete response has a 2.xx CoAP code."""
+        return self.complete and self.code >> 5 == 2
+
+    def __repr__(self):
+        return (
+            'PlaintextOcfResourceResult('
+            f'complete={self.complete!r}, successful={self.successful!r}, '
+            f'code={self.code!r}, payload_bytes={len(self.payload)}, '
+            f'blocks_received={self.blocks_received}, '
+            f'attempts={self.attempts}, '
+            f'response_received={self.response_received!r}, '
+            f'error_code={self.error_code!r})'
+        )
 
 
 @dataclass(frozen=True, slots=True, repr=False)
@@ -126,15 +174,21 @@ class _TransferResult:
     code: int | None
     family: int | None
     source_key: tuple[bytes, int] | None
+    blocks_received: int
+    content_format: int | None
+    size2: int | None
     attempts: int
     response_received: bool
 
 
-def _validate_options(discovery_port, timeout, retries, family):
-    if isinstance(discovery_port, bool) or not isinstance(discovery_port, int):
-        raise TypeError('discovery_port must be an integer')
-    if not 1 <= discovery_port <= 65535:
-        raise ValueError('discovery_port must be between 1 and 65535')
+def _validate_port(port, *, name):
+    if isinstance(port, bool) or not isinstance(port, int):
+        raise TypeError(f'{name} must be an integer')
+    if not 1 <= port <= 65535:
+        raise ValueError(f'{name} must be between 1 and 65535')
+
+
+def _validate_transport_options(timeout, retries, family):
     if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
         raise TypeError('timeout must be a number')
     if not math.isfinite(timeout) or not 0 < timeout <= 30:
@@ -147,6 +201,51 @@ def _validate_options(discovery_port, timeout, retries, family):
         raise TypeError('family must be an address-family integer')
     if family not in (socket.AF_UNSPEC, socket.AF_INET, socket.AF_INET6):
         raise ValueError('family must be AF_UNSPEC, AF_INET, or AF_INET6')
+
+
+def _validate_options(discovery_port, timeout, retries, family):
+    _validate_port(discovery_port, name='discovery_port')
+    _validate_transport_options(timeout, retries, family)
+
+
+def _validated_text_values(values, *, name, allow_empty):
+    """Return bounded UTF-8 option values without echoing caller data."""
+    if isinstance(values, (str, bytes, bytearray, memoryview)):
+        raise TypeError(f'{name} must be an iterable of strings')
+    try:
+        iterator = iter(values)
+    except TypeError:
+        raise TypeError(f'{name} must be an iterable of strings') from None
+
+    result = []
+    for value in iterator:
+        if len(result) >= _MAX_REQUEST_OPTION_COUNT:
+            raise ValueError(f'{name} must contain at most 32 values')
+        if not isinstance(value, str):
+            raise TypeError(f'{name} values must be strings')
+        try:
+            encoded = value.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ValueError(f'{name} values must be valid UTF-8') from None
+        if (not allow_empty and not encoded) or \
+                len(encoded) > _MAX_REQUEST_OPTION_BYTES:
+            raise ValueError(f'{name} values must be non-empty and bounded')
+        result.append(encoded)
+    return tuple(result)
+
+
+def _validated_resource_target(href, query):
+    if not isinstance(href, str):
+        raise TypeError('href must be a string')
+    if (not href.startswith('/') or href == '/' or href.endswith('/')
+            or '//' in href or '?' in href or '#' in href):
+        raise ValueError(
+            'href must be an absolute resource path with non-empty segments')
+    path = _validated_text_values(
+        href[1:].split('/'), name='href segments', allow_empty=False)
+    query = _validated_text_values(
+        query, name='query', allow_empty=False)
+    return path, query
 
 
 def _host_key(family, sockaddr):
@@ -203,6 +302,19 @@ def _open_routes(endpoints, selector):
                 except OSError:
                     pass
     return routes
+
+
+def _close_routes(routes, selector):
+    for route in routes:
+        try:
+            selector.unregister(route.sock)
+        except (KeyError, OSError, ValueError):
+            pass
+        try:
+            route.sock.close()
+        except OSError:
+            pass
+    selector.close()
 
 
 def _decode_cbor(payload):
@@ -382,19 +494,25 @@ def _fallback_secure_ports_from_payload(payload, family, source_key):
 def _transfer_result(
         status, *, attempts, response_received, accumulator=None, route=None):
     complete = accumulator is not None and accumulator.complete
+    successful = complete and accumulator.code >> 5 == 2
     return _TransferResult(
         status=status,
         payload=accumulator.payload if complete else b'',
         code=accumulator.code if complete else None,
         family=route.endpoint.family if complete and route is not None else None,
         source_key=route.host_key if complete and route is not None else None,
+        blocks_received=(
+            accumulator.blocks_received if accumulator is not None else 0),
+        content_format=(
+            accumulator.content_format if successful else None),
+        size2=accumulator.size2 if successful else None,
         attempts=attempts,
         response_received=response_received,
     )
 
 
-def _fetch_directory(
-        routes, selector, *, query, cutoff, retries, used_mids):
+def _fetch_resource(
+        routes, selector, *, path, query, cutoff, retries, used_mids):
     """Fetch one representation without retaining an address in its repr."""
     token = secrets.token_bytes(8)
     accumulator = Block2Accumulator(
@@ -431,7 +549,7 @@ def _fetch_directory(
                 TYPE_NON,
                 mid,
                 token,
-                (b'oic', b'res'),
+                path,
                 query,
                 block_number=(
                     accumulator.expected_number
@@ -554,12 +672,14 @@ def _fetch_directory(
                 status,
                 attempts=attempts,
                 response_received=response_received,
+                accumulator=accumulator,
             )
 
     return _transfer_result(
         _TRANSFER_MALFORMED,
         attempts=attempts,
         response_received=response_received,
+        accumulator=accumulator,
     )
 
 
@@ -582,6 +702,79 @@ def _extraction_for_transfer(transfer, *, fallback):
         if fallback else _primary_secure_ports_from_payload
     )
     return extractor(transfer.payload, transfer.family, transfer.source_key)
+
+
+def _resource_result(transfer):
+    error_codes = {
+        _TRANSFER_ENDPOINT_UNAVAILABLE: 'endpoint_unavailable',
+        _TRANSFER_MALFORMED: 'malformed_ocf_response',
+        _TRANSFER_NO_RESPONSE: 'no_ocf_response',
+    }
+    error_code = error_codes.get(transfer.status)
+    return PlaintextOcfResourceResult(
+        code=transfer.code,
+        payload=transfer.payload,
+        blocks_received=transfer.blocks_received,
+        content_format=transfer.content_format,
+        size2=transfer.size2,
+        attempts=transfer.attempts,
+        response_received=transfer.response_received,
+        error_code=error_code,
+    )
+
+
+def read_plaintext_ocf_resource(
+        host, href, *, query=(), port=_DISCOVERY_PORT, timeout=3.0,
+        retries=1, family=socket.AF_UNSPEC):
+    """Read one known plaintext OCF resource under fixed transfer bounds.
+
+    ``href`` is an absolute resource path and ``query`` contains individual
+    URI-Query values. ``port`` must already be known; this function does not
+    scan or multicast. A response may originate from a different port on the
+    resolved target address, which is pinned after the first correlated
+    response for all Block2 continuations.
+
+    Name resolution happens synchronously first. ``timeout`` then bounds the
+    complete request, retries, and Block2 continuations. The result preserves
+    complete non-2.xx responses so callers can distinguish authorization from
+    reachability. This plaintext read neither authenticates the appliance nor
+    grants access to protected resources.
+    """
+    _validate_port(port, name='port')
+    _validate_transport_options(timeout, retries, family)
+    path, query = _validated_resource_target(href, query)
+
+    try:
+        endpoints = resolve_udp_endpoints(host, port, family=family)
+    except OSError:
+        return PlaintextOcfResourceResult(
+            None, b'', 0, None, None, 0, False,
+            error_code='endpoint_unavailable',
+        )
+
+    selector = selectors.DefaultSelector()
+    routes = _open_routes(endpoints, selector)
+    if not routes:
+        selector.close()
+        return PlaintextOcfResourceResult(
+            None, b'', 0, None, None, 0, False,
+            error_code='endpoint_unavailable',
+        )
+
+    deadline = time.monotonic() + float(timeout)
+    try:
+        transfer = _fetch_resource(
+            routes,
+            selector,
+            path=path,
+            query=query,
+            cutoff=deadline,
+            retries=retries,
+            used_mids=set(),
+        )
+        return _resource_result(transfer)
+    finally:
+        _close_routes(routes, selector)
 
 
 def discover_ocf_secure_ports(
@@ -623,9 +816,10 @@ def discover_ocf_secure_ports(
     used_mids = set()
 
     try:
-        primary = _fetch_directory(
+        primary = _fetch_resource(
             routes,
             selector,
+            path=(b'oic', b'res'),
             query=_PRIMARY_QUERY,
             cutoff=primary_cutoff,
             retries=retries,
@@ -654,9 +848,10 @@ def discover_ocf_secure_ports(
         # with no usable secure eps are the only fallback conditions. The
         # fallback gets a fresh token, accumulator, and peer pin and starts at
         # the original public discovery routes.
-        fallback_result = _fetch_directory(
+        fallback_result = _fetch_resource(
             routes,
             selector,
+            path=(b'oic', b'res'),
             query=_FALLBACK_QUERY,
             cutoff=deadline,
             retries=retries,
@@ -685,13 +880,4 @@ def discover_ocf_secure_ports(
                 (), attempts, response_received, 'malformed_ocf_response')
         return _result((), attempts, response_received, 'no_secure_ports')
     finally:
-        for route in routes:
-            try:
-                selector.unregister(route.sock)
-            except (KeyError, OSError, ValueError):
-                pass
-            try:
-                route.sock.close()
-            except OSError:
-                pass
-        selector.close()
+        _close_routes(routes, selector)

--- a/tests/test_plaintext_ocf_resource.py
+++ b/tests/test_plaintext_ocf_resource.py
@@ -1,0 +1,458 @@
+"""Bounded plaintext OCF resource reads stay source-correlated and raw."""
+
+import inspect
+import socket
+import threading
+import time
+import traceback
+from dataclasses import FrozenInstanceError
+
+import cbor2
+import pytest
+
+from smartthings_local.errors import EndpointError
+from smartthings_local.protocol import ocf_discovery as discovery
+from smartthings_local.protocol.coap import (
+    ACCEPT,
+    BLOCK2,
+    CF_CBOR,
+    CONTENT_FORMAT,
+    ETAG,
+    METHOD_GET,
+    SIZE2,
+    TYPE_ACK,
+    TYPE_CON,
+    TYPE_NON,
+    URI_PATH,
+    URI_QUERY,
+    block_value,
+    build_coap,
+    parse_coap,
+)
+
+
+def _option_map(options):
+    result = {}
+    for number, value in options:
+        result.setdefault(number, []).append(value)
+    return result
+
+
+def _uint_bytes(value):
+    length = max(1, (value.bit_length() + 7) // 8)
+    return value.to_bytes(length, 'big')
+
+
+def test_public_exports_and_signature_are_explicit():
+    assert 'PlaintextOcfResourceResult' in discovery.__all__
+    assert 'read_plaintext_ocf_resource' in discovery.__all__
+    assert list(inspect.signature(
+        discovery.read_plaintext_ocf_resource).parameters) == [
+            'host', 'href', 'query', 'port', 'timeout', 'retries', 'family']
+
+
+def test_dynamic_source_block2_read_preserves_path_query_and_metadata():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    responder = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    listener.bind(('127.0.0.1', 0))
+    responder.bind(('127.0.0.1', 0))
+    listener.settimeout(2.0)
+    responder.settimeout(2.0)
+    body = cbor2.dumps({'value': 'x' * 80})
+    assert 64 < len(body) <= 128
+    errors = []
+
+    def respond():
+        try:
+            first_request, client = listener.recvfrom(8192)
+            first = parse_coap(first_request)
+            first_options = _option_map(first[4])
+            assert first[:2] == (TYPE_NON, METHOD_GET)
+            assert len(first[3]) == 8 and first[5] == b''
+            assert first_options[URI_PATH] == [b'oic', b'res']
+            assert first_options[URI_QUERY] == [
+                b'if=oic.if.baseline', b'rt=oic.wk.d']
+            assert first_options[ACCEPT] == [CF_CBOR]
+            assert BLOCK2 not in first_options
+
+            common = [
+                (CONTENT_FORMAT, CF_CBOR),
+                (ETAG, b'fixture'),
+                (SIZE2, _uint_bytes(len(body))),
+            ]
+            responder.sendto(
+                build_coap(
+                    TYPE_CON,
+                    0x45,
+                    0x7001,
+                    first[3],
+                    [*common, (BLOCK2, block_value(0, 1, 2))],
+                    body[:64],
+                ),
+                client,
+            )
+
+            acknowledgement, acknowledgement_peer = responder.recvfrom(8192)
+            assert acknowledgement_peer == client
+            assert parse_coap(acknowledgement)[:4] == (
+                TYPE_ACK, 0, 0x7001, b'')
+
+            continuation, continuation_client = responder.recvfrom(8192)
+            second = parse_coap(continuation)
+            second_options = _option_map(second[4])
+            assert continuation_client == client
+            assert second[:2] == (TYPE_NON, METHOD_GET)
+            assert second[3] == first[3] and second[2] != first[2]
+            assert second[5] == b''
+            assert second_options[URI_PATH] == [b'oic', b'res']
+            assert second_options[URI_QUERY] == [
+                b'if=oic.if.baseline', b'rt=oic.wk.d']
+            assert second_options[ACCEPT] == [CF_CBOR]
+            assert second_options[BLOCK2] == [block_value(1, 0, 2)]
+
+            responder.sendto(
+                build_coap(
+                    TYPE_NON,
+                    0x45,
+                    0x7002,
+                    first[3],
+                    [(BLOCK2, block_value(1, 0, 2))],
+                    body[64:],
+                ),
+                client,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    try:
+        result = discovery.read_plaintext_ocf_resource(
+            '127.0.0.1',
+            '/oic/res',
+            query=('if=oic.if.baseline', 'rt=oic.wk.d'),
+            port=listener.getsockname()[1],
+            timeout=1.5,
+            retries=1,
+            family=socket.AF_INET,
+        )
+    finally:
+        thread.join(timeout=3.0)
+        listener.close()
+        responder.close()
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert result.code == 0x45
+    assert result.payload == body
+    assert result.blocks_received == 2
+    assert result.content_format == int.from_bytes(CF_CBOR, 'big')
+    assert result.size2 == len(body)
+    assert result.attempts == 2
+    assert result.response_received
+    assert result.error_code is None
+    assert result.complete and result.successful
+
+
+def test_complete_unauthorized_response_preserves_code_and_body():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    listener.bind(('127.0.0.1', 0))
+    listener.settimeout(2.0)
+    body = b'authorization required'
+    errors = []
+
+    def respond():
+        try:
+            request, client = listener.recvfrom(8192)
+            token = parse_coap(request)[3]
+            listener.sendto(
+                build_coap(
+                    TYPE_NON,
+                    0x81,
+                    0x7101,
+                    token,
+                    [(CONTENT_FORMAT, b'')],
+                    body,
+                ),
+                client,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    try:
+        result = discovery.read_plaintext_ocf_resource(
+            '127.0.0.1',
+            '/temperatures/0',
+            port=listener.getsockname()[1],
+            timeout=1.0,
+            retries=0,
+            family=socket.AF_INET,
+        )
+    finally:
+        thread.join(timeout=2.0)
+        listener.close()
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert result.code == 0x81
+    assert result.payload == body
+    assert result.blocks_received == 1
+    assert result.content_format is None
+    assert result.size2 is None
+    assert result.response_received
+    assert result.error_code is None
+    assert result.complete and not result.successful
+
+
+def test_retry_keeps_token_changes_mid_and_stays_in_one_deadline():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    listener.bind(('127.0.0.1', 0))
+    listener.settimeout(2.0)
+    errors = []
+
+    def respond():
+        try:
+            first_request, client = listener.recvfrom(8192)
+            second_request, second_client = listener.recvfrom(8192)
+            first = parse_coap(first_request)
+            second = parse_coap(second_request)
+            assert second_client == client
+            assert first[:2] == second[:2] == (TYPE_NON, METHOD_GET)
+            assert first[3] == second[3]
+            assert first[2] != second[2]
+            listener.sendto(
+                build_coap(
+                    TYPE_NON,
+                    0x45,
+                    0x7201,
+                    second[3],
+                    [],
+                    cbor2.dumps({'value': 1}),
+                ),
+                client,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    started = time.monotonic()
+    try:
+        result = discovery.read_plaintext_ocf_resource(
+            '127.0.0.1',
+            '/oic/d',
+            port=listener.getsockname()[1],
+            timeout=0.7,
+            retries=1,
+            family=socket.AF_INET,
+        )
+    finally:
+        elapsed = time.monotonic() - started
+        thread.join(timeout=2.0)
+        listener.close()
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert result.successful
+    assert result.attempts == 2
+    assert elapsed < 1.0
+
+
+def test_partial_block2_transfer_returns_no_partial_payload():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    listener.bind(('127.0.0.1', 0))
+    listener.settimeout(2.0)
+    errors = []
+
+    def respond():
+        try:
+            request, client = listener.recvfrom(8192)
+            token = parse_coap(request)[3]
+            listener.sendto(
+                build_coap(
+                    TYPE_NON,
+                    0x45,
+                    0x7301,
+                    token,
+                    [(BLOCK2, block_value(0, 1, 2))],
+                    b'x' * 64,
+                ),
+                client,
+            )
+            continuation, continuation_client = listener.recvfrom(8192)
+            parsed = parse_coap(continuation)
+            assert continuation_client == client
+            assert parsed[3] == token
+            assert _option_map(parsed[4])[BLOCK2] == [
+                block_value(1, 0, 2)]
+        except Exception as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    started = time.monotonic()
+    try:
+        result = discovery.read_plaintext_ocf_resource(
+            '127.0.0.1',
+            '/oic/res',
+            port=listener.getsockname()[1],
+            timeout=0.4,
+            retries=0,
+            family=socket.AF_INET,
+        )
+    finally:
+        elapsed = time.monotonic() - started
+        thread.join(timeout=2.0)
+        listener.close()
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert result.code is None
+    assert result.payload == b''
+    assert result.blocks_received == 1
+    assert result.response_received
+    assert result.error_code == 'malformed_ocf_response'
+    assert not result.complete and not result.successful
+    assert elapsed < 0.8
+
+
+def test_wrong_token_confirmable_response_is_ignored_without_ack():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    listener.bind(('127.0.0.1', 0))
+    listener.settimeout(0.4)
+    errors = []
+    unexpected_datagrams = []
+
+    def respond():
+        try:
+            request, client = listener.recvfrom(8192)
+            token = parse_coap(request)[3]
+            listener.sendto(
+                build_coap(
+                    TYPE_CON,
+                    0x45,
+                    0x7401,
+                    b'badtoken',
+                    [],
+                    cbor2.dumps({'wrong': True}),
+                ),
+                client,
+            )
+            listener.sendto(
+                build_coap(
+                    TYPE_NON,
+                    0x45,
+                    0x7402,
+                    token,
+                    [],
+                    cbor2.dumps({'right': True}),
+                ),
+                client,
+            )
+            try:
+                unexpected_datagrams.append(listener.recvfrom(8192))
+            except TimeoutError:
+                pass
+        except Exception as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    try:
+        result = discovery.read_plaintext_ocf_resource(
+            '127.0.0.1',
+            '/oic/d',
+            port=listener.getsockname()[1],
+            timeout=0.8,
+            retries=0,
+            family=socket.AF_INET,
+        )
+    finally:
+        thread.join(timeout=2.0)
+        listener.close()
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert unexpected_datagrams == []
+    assert result.successful
+    assert cbor2.loads(result.payload) == {'right': True}
+
+
+def test_resolution_failure_and_result_repr_are_redacted(monkeypatch):
+    remote_host = 'private-appliance.invalid'
+    resource = '/private/resource'
+
+    def fail(host, port, *, family):
+        assert host == remote_host
+        assert port == 5683
+        assert family == socket.AF_INET6
+        raise EndpointError()
+
+    monkeypatch.setattr(discovery, 'resolve_udp_endpoints', fail)
+
+    result = discovery.read_plaintext_ocf_resource(
+        remote_host, resource, family=socket.AF_INET6)
+    rendered = repr(result) + ''.join(
+        traceback.format_exception(EndpointError()))
+
+    assert result.error_code == 'endpoint_unavailable'
+    assert result.attempts == 0
+    assert remote_host not in rendered
+    assert resource not in rendered
+    assert 'private body' not in repr(
+        discovery.PlaintextOcfResourceResult(
+            0x45, b'private body', 1, 60, 12, 1, True))
+
+
+def test_result_is_immutable():
+    result = discovery.PlaintextOcfResourceResult(
+        0x45, b'body', 1, 60, 4, 1, True)
+
+    with pytest.raises(FrozenInstanceError):
+        result.attempts = 2
+
+
+@pytest.mark.parametrize(
+    ('href', 'kwargs', 'error_type'),
+    (
+        (None, {}, TypeError),
+        (b'/oic/d', {}, TypeError),
+        ('oic/d', {}, ValueError),
+        ('/', {}, ValueError),
+        ('/oic/', {}, ValueError),
+        ('/oic//d', {}, ValueError),
+        ('/oic/d?x=1', {}, ValueError),
+        ('/oic/d#fragment', {}, ValueError),
+        ('/' + '/'.join(['x'] * 33), {}, ValueError),
+        ('/' + 'x' * 1025, {}, ValueError),
+        ('/\ud800', {}, ValueError),
+        ('/oic/d', {'query': 'if=oic.if.baseline'}, TypeError),
+        ('/oic/d', {'query': ('x=1', b'x=2')}, TypeError),
+        ('/oic/d', {'query': ('',)}, ValueError),
+        ('/oic/d', {'query': tuple('x' for _ in range(33))}, ValueError),
+        ('/oic/d', {'query': ('x' * 1025,)}, ValueError),
+        ('/oic/d', {'query': ('\ud800',)}, ValueError),
+        ('/oic/d', {'port': 0}, ValueError),
+        ('/oic/d', {'port': True}, TypeError),
+        ('/oic/d', {'timeout': 0}, ValueError),
+        ('/oic/d', {'timeout': float('nan')}, ValueError),
+        ('/oic/d', {'timeout': True}, TypeError),
+        ('/oic/d', {'retries': 5}, ValueError),
+        ('/oic/d', {'retries': True}, TypeError),
+        ('/oic/d', {'family': 9999}, ValueError),
+        ('/oic/d', {'family': 'AF_INET'}, TypeError),
+    ),
+)
+def test_invalid_inputs_fail_before_network(
+        monkeypatch, href, kwargs, error_type):
+    def unexpected_resolution(*args, **network_kwargs):
+        raise AssertionError((args, network_kwargs))
+
+    monkeypatch.setattr(
+        discovery, 'resolve_udp_endpoints', unexpected_resolution)
+
+    with pytest.raises(error_type):
+        discovery.read_plaintext_ocf_resource(
+            '192.0.2.20', href, **kwargs)


### PR DESCRIPTION
## Summary

- Add `read_plaintext_ocf_resource()` for one known absolute href and public request port.
- Reuse the source-bound GET/Block2 engine from advertised endpoint discovery instead of adding a second UDP implementation.
- Return an immutable result with the raw response code and body, Block2 metadata, attempt count, and fixed failure classification.

## Why

Some Family Hub responses span multiple Block2 packets and can arrive from a different UDP source port than the request port. Callers that need `/oic/d`, `/oic/res`, or another public resource currently have to duplicate the token, source-pinning, continuation, and deadline logic already used by discovery.

The latest hardware results in #16 also show why the response code needs to remain visible: a reachable endpoint or completed handshake does not imply that every resource is authorized. A complete 4.xx or 5.xx response is therefore returned as a complete non-success read, with its body intact.

## Behavior

- Validates the absolute href, query values, port, deadline, retries, and address family before opening a socket.
- Keeps one token across retries and Block2 continuations, uses a new MID for each NON request, and pins the first correlated response peer.
- ACKs only accepted correlated CON responses.
- Applies one deadline and the existing 32-block, 64-KiB, and datagram bounds.
- Leaves CBOR schema decoding, authentication, and authorization decisions to the caller.

This branch is directly on `main` after #48 and is independent of #49 and #50; it does not touch `dtls_session.py`.

## Validation

- 67 focused discovery/resource-read tests
- 492 full tests on Python 3.14
- 492 full tests on Python 3.11 with the dependency floor
- wheel/sdist content checks and isolated import tests
- share-safety check

Related: #16