### PR TITLE
Preserve a first-position device-tree resource

### DIFF
--- a/smartthings_local/ocf/state_cache.py
+++ b/smartthings_local/ocf/state_cache.py
@@ -62,8 +62,8 @@ class StateCache:
     @staticmethod
     def index_device_tree(device0_body) -> dict[str, dict]:
         """Turn a /device/0 CBOR list-of-{href, rep} sweep response into
-        a dict keyed by href. Entry [0] is the device-level rep itself
-        and isn't useful here, so it's skipped.
+        a dict keyed by href. Some responses put a device-level `/device/0`
+        rep first, while others put a normal resource in that slot.
 
         Replaces the old standalone sensors.index_links — folded in
         here because every current and future caller immediately feeds
@@ -71,8 +71,12 @@ class StateCache:
         out: dict[str, dict] = {}
         if not isinstance(device0_body, list):
             return out
-        for entry in device0_body[1:]:
-            if isinstance(entry, dict) and 'href' in entry:
+        for entry in device0_body:
+            if (
+                isinstance(entry, dict)
+                and 'href' in entry
+                and entry['href'] != '/device/0'
+            ):
                 out[entry['href']] = entry.get('rep') or {}
         return out
 

--- a/tests/test_state_cache.py
+++ b/tests/test_state_cache.py
@@ -17,6 +17,24 @@ def test_index_device_tree_skips_device_level_entry_at_index_zero():
     assert '/device/0' not in indexed
 
 
+def test_index_device_tree_keeps_resource_entry_at_index_zero():
+    tree = [
+        {
+            'href': '/information/vs/0',
+            'rep': {'x.com.samsung.da.modelNum': 'synthetic-model'},
+        },
+        {'rt': ['x.com.samsung.devcol']},
+        {'href': '/configuration/vs/0', 'rep': {'configured': True}},
+    ]
+
+    assert StateCache.index_device_tree(tree) == {
+        '/information/vs/0': {
+            'x.com.samsung.da.modelNum': 'synthetic-model',
+        },
+        '/configuration/vs/0': {'configured': True},
+    }
+
+
 def test_index_device_tree_stub_entry_becomes_empty_dict():
     tree = [
         {'href': '/device/0', 'rep': {}},


### PR DESCRIPTION
## Summary

- inspect every href-bearing entry in a `/device/0` batch
- continue excluding the `/device/0` container representation itself
- cover a batch where `/information/vs/0` is the first entry

## Why

`StateCache.index_device_tree()` currently drops position zero unconditionally. Some batch layouts put an ordinary resource there rather than the device container, which causes that complete representation to disappear from the indexed sweep. The href identifies the container reliably; its position does not.

## Validation

- 677 SmartThings-Local tests
- 1,834 LocalThings tests against this branch
- wheel and sdist content validation
- share-safety scan