### PR TITLE
Separate Observe registration answers from pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ Optional `on_observe_pending`, `on_legacy_notification`, and `on_observe_error`
 constructor callbacks let consumers keep that compatibility path distinct from
 confirmed RFC notifications and ordinary polling.
 
+`on_observe_delivery` replaces `on_notification` for consumers that need the
+whole relation context rather than `(href, payload)`. It receives one
+`ObserveDelivery`, whose `registration` field separates the server's answer to
+the register CON from a change the server chose to send, and whose `query`
+completes the relation identity when one href carries several query-qualified
+relations. `sequence` is the Observe option value, or `None` on the optionless
+responses some firmware sends. Setting it suppresses `on_notification` and
+`on_legacy_notification`, so representations are delivered once:
+
+```python
+def on_delivery(delivery):
+    if delivery.registration:
+        seed(delivery.href, delivery.payload)   # answered because we asked
+    else:
+        record_push(delivery.href, delivery.payload)
+
+sess = DtlsCoapSession(..., on_observe_delivery=on_delivery)
+```
+
 Periodic renewal can target only the relations that need it; unrelated
 observations remain active. Existing query variants are preserved unless the
 caller supplies an explicit replacement:
@@ -740,7 +759,9 @@ There are two parallel paths between the appliance and the app over the local Co
 
 In normal operation both happen at once: an OBSERVE notification arrives first, the cache absorbs it, and the next-poll timer for that resource is reset. In an air-gapped LAN the app keeps working. Only the worst-case freshness changes (from ~100 ms with push to ≤1 s on hot-tier resources via polling). Reads, writes, and HA entities behave identically.
 
-Which path is doing the work is visible in Home Assistant. The bridge publishes per-appliance diagnostic entities including **Push Active** (on while OBSERVE is firing), **Last Update Source** (`observe` / `poll` / `sweep` / `optimistic`), **Last OBSERVE Age**, **Poll Max RTT**, **Slow Polls (window)**, **Poll Errors (window)**, and **Stalest Resource Age**, all under each device's Diagnostic section.
+Which path is doing the work is visible in Home Assistant. The bridge publishes per-appliance diagnostic entities including **Push Active** (on while OBSERVE is firing), **Last Update Source** (`observe` / `observe-register` / `poll` / `sweep` / `optimistic`), **Last OBSERVE Age**, **Poll Max RTT**, **Slow Polls (window)**, **Poll Errors (window)**, and **Stalest Resource Age**, all under each device's Diagnostic section.
+
+**Push Active** counts only what the appliance sent of its own accord. A device answers every OBSERVE register CON with the current representation, and that answer reaches the notification callback exactly as a spontaneous notification does. The bridge reads `ObserveDelivery.registration` to tell them apart and records the answer as `observe-register`, so an appliance with no route to Samsung's cloud reads offline instead of going online for the window after every connect.
 
 ---
 

--- a/mqtt_demo/bridge.py
+++ b/mqtt_demo/bridge.py
@@ -197,23 +197,35 @@ class PushBridge:
                 self._last_observe_change_ts = self.last_change_ts
         self.maybe_publish_state()
 
-    def _on_notification(self, href, payload_bytes):
-        """Reader-thread callback for OBSERVE notifications. Large
-        resources (oven /mode/vs/0 ~9KB) arrive truncated with Block2.M=1
-        and we use cbor-decode failure as the partial signal."""
+    def _on_observe_delivery(self, delivery) -> None:
+        """Reader-thread callback for everything arriving on an OBSERVE
+        relation.
+
+        The session answers the question the bridge cannot: whether this
+        representation is the device's reply to our register CON or a
+        change it chose to send (#41). Only the latter is push.
+        """
+        self._on_notification(
+            delivery.href, delivery.payload,
+            source=('observe-register' if delivery.registration
+                    else 'observe'))
+
+    def _on_notification(self, href, payload_bytes, source='observe'):
+        """Large resources (oven /mode/vs/0 ~9KB) arrive truncated with
+        Block2.M=1 and we use cbor-decode failure as the partial signal."""
         if not payload_bytes:
-            self._schedule_fetchback(href)
+            self._schedule_fetchback(href, source=source)
             return
         try:
             rep = cbor2.loads(payload_bytes)
         except Exception:
-            self._schedule_fetchback(href)
+            self._schedule_fetchback(href, source=source)
             return
         if not isinstance(rep, dict):
             return
         if DEBUG_BRIDGE:
             self._debug_log_rep(href, rep)
-        self.cache.apply_rep(href, rep, source='observe')
+        self.cache.apply_rep(href, rep, source=source)
 
     def _debug_log_rep(self, href, rep):
         if href == '/mode/vs/0' and isinstance(rep, dict):
@@ -223,18 +235,20 @@ class PushBridge:
         elif href in ('/operational/state/vs/0', '/oven/vs/0', '/power/vs/0'):
             self.log.info("REP %s = %r", href, rep)
 
-    def _schedule_fetchback(self, href, delay_s: float = 0.0):
+    def _schedule_fetchback(self, href, delay_s: float = 0.0,
+                            source: str = 'observe'):
         with self._fetch_lock:
             gen = self._fetch_gen.get(href, 0) + 1
             self._fetch_gen[href] = gen
         threading.Thread(
             target=self._fetch_back,
-            args=(href, delay_s, gen),
+            args=(href, delay_s, gen, source),
             daemon=True,
             name=f'fetch{href}',
         ).start()
 
-    def _fetch_back(self, href, delay_s: float, gen: int):
+    def _fetch_back(self, href, delay_s: float, gen: int,
+                    source: str = 'observe'):
         if delay_s > 0 and self.stop.wait(delay_s):
             return
         with self._fetch_lock:
@@ -261,7 +275,7 @@ class PushBridge:
             self.log.warning("fetchback %s cbor: %s", href, e)
             return
         if isinstance(rep, dict):
-            self.cache.apply_rep(href, rep, source='observe')
+            self.cache.apply_rep(href, rep, source=source)
 
     def _retag_logger_with_serial(self):
         if self._serial is not None:
@@ -347,7 +361,7 @@ class PushBridge:
             self.app.ip, port,
             cert_path=self.shared.CERT_PATH,
             key_path=self.shared.KEY_PATH,
-            on_notification=self._on_notification,
+            on_observe_delivery=self._on_observe_delivery,
             local_port=DTLS_LOCAL_PORT_BASE + self.app.index,
             write_max_attempts=self.shared.WRITE_MAX_ATTEMPTS,
         )

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -164,6 +164,33 @@ class _EtagChanged(Exception):
     transfer, so the blocks in hand are from two different versions."""
 
 
+def _openssl_error_reasons(error):
+    """The reason strings OpenSSL recorded, and nothing else.
+
+    A handshake that dies at the TLS layer raises ``SSL.Error``, and the
+    only thing that says why is the alert inside it. That detail cannot
+    go into the raised ``SessionError``: the errors module deliberately
+    refuses arbitrary detail, because backend errors elsewhere can carry
+    remote endpoints, local paths or credential metadata. So it goes to
+    the local log instead, narrowed to the reason strings.
+
+    Those are protocol vocabulary -- ``tlsv1 alert unknown ca``,
+    ``sslv3 alert handshake failure``, ``Unexpected EOF`` -- and name
+    the failure without naming the peer.
+    """
+    reasons = []
+    first = error.args[0] if error.args else None
+    if isinstance(first, (list, tuple)):
+        for entry in first:
+            if isinstance(entry, (list, tuple)) and entry:
+                reasons.append(str(entry[-1]))
+            elif isinstance(entry, str):
+                reasons.append(entry)
+    else:
+        reasons.extend(arg for arg in error.args if isinstance(arg, str))
+    return ', '.join(r for r in reasons if r) or type(error).__name__
+
+
 @dataclass(frozen=True, slots=True)
 class ObserveDelivery:
     """One representation delivered on an Observe relation.
@@ -733,8 +760,12 @@ class DtlsCoapSession:
                 )
             except _HandshakeCancelled:
                 cancelled = True
-            except SSL.Error:
+            except SSL.Error as e:
                 backend_failed = True
+                # The alert is the whole diagnosis and the raised error
+                # is redacted by contract, so record it here or lose it.
+                logger.warning("dtls handshake failed at the TLS layer: %s",
+                               _openssl_error_reasons(e))
             except OSError:
                 io_failed = True
         finally:

--- a/smartthings_local/protocol/dtls_session.py
+++ b/smartthings_local/protocol/dtls_session.py
@@ -164,6 +164,35 @@ class _EtagChanged(Exception):
     transfer, so the blocks in hand are from two different versions."""
 
 
+@dataclass(frozen=True, slots=True)
+class ObserveDelivery:
+    """One representation delivered on an Observe relation.
+
+    ``registration`` separates the server's answer to the register CON
+    from a change the server chose to send. RFC 7641 §3.2 makes the
+    first response on the token the answer to the registration, and a
+    consumer that treats it as a push reports a device as pushing when
+    it has only replied to being asked. The session is the only layer
+    that can tell them apart, since the token, the Message ID and the
+    Observe option are all resolved here and none of them reach a
+    caller.
+
+    ``query`` completes the relation identity: the same href can carry
+    several query-qualified relations, each registering separately.
+
+    ``sequence`` is the Observe option value (§3.4), or ``None`` on the
+    optionless responses some Samsung firmware sends. ``legacy`` marks a
+    relation promoted to that optionless path.
+    """
+
+    href: str
+    payload: bytes
+    query: tuple[str, ...] = ()
+    registration: bool = False
+    sequence: int | None = None
+    legacy: bool = False
+
+
 @dataclass(slots=True)
 class _MidExchange:
     """One pending request, indexed independently by token and MID."""
@@ -414,7 +443,8 @@ class DtlsCoapSession:
                  auth: AuthenticationProvider | None = None,
                  on_legacy_notification=None,
                  on_observe_pending=None,
-                 on_observe_error=None):
+                 on_observe_error=None,
+                 on_observe_delivery=None):
         file_supplied = cert_path is not None or key_path is not None
         memory_supplied = cert_pem is not None or key_pem is not None
         if auth is not None and (file_supplied or memory_supplied):
@@ -448,6 +478,11 @@ class DtlsCoapSession:
         self.on_legacy_notification = on_legacy_notification
         self.on_observe_pending = on_observe_pending
         self.on_observe_error = on_observe_error
+        # fn(ObserveDelivery). Takes precedence over on_notification and
+        # on_legacy_notification, which carry only (href, payload) and so
+        # cannot express which delivery answered the register CON, nor
+        # which query-qualified relation it belongs to.
+        self.on_observe_delivery = on_observe_delivery
         self.mtu = mtu
         self._min_req_interval = 1.0 / rate_limit_rps
         self._write_max_attempts = max(1, int(write_max_attempts))
@@ -1039,6 +1074,24 @@ class DtlsCoapSession:
             self._legacy_observe_mids.clear()
             self._observe_sequences.clear()
 
+    def _observe_sequence_for(self, href, query):
+        """The Observe value last recorded for one relation, if any.
+
+        A refetched representation is delivered after its triggering
+        notification has already been ordered, so the sequence to report
+        is the one that ordering recorded. Optionless relations have
+        none.
+        """
+        with self._state_lock:
+            for tok, observed_href in self._observe_tokens.items():
+                if observed_href != href or \
+                        self._observe_queries.get(tok, ()) != query:
+                    continue
+                recorded = self._observe_sequences.get(tok)
+                if recorded is not None:
+                    return recorded[0]
+        return None
+
     def _observe_relation_active(self, href, query, legacy):
         """Return whether one relation still owns this callback identity."""
         with self._state_lock:
@@ -1316,6 +1369,8 @@ class DtlsCoapSession:
                 value for number, value in ropts if number == OBSERVE
             ]
             legacy = False
+            registration = False
+            sequence = None
             if observe_values:
                 if len(observe_values) != 1 or len(observe_values[0]) > 3:
                     logger.debug("observe %s: malformed Observe option", href)
@@ -1327,6 +1382,12 @@ class DtlsCoapSession:
                     if not self._observe_sequence_is_fresh(
                             previous, sequence, received_at):
                         return
+                    # Nothing recorded for this token yet, so this is the
+                    # first response it has carried: the answer to the
+                    # register CON. Retiring a token on unsubscribe or
+                    # refresh clears the entry, so a re-registration is
+                    # recognised as one without any caller bookkeeping.
+                    registration = previous is None
                     self._observe_sequences[tok] = (sequence, received_at)
                     self._observe_plain_response_mids.pop(tok, None)
                     self._legacy_observe_tokens.discard(tok)
@@ -1352,6 +1413,11 @@ class DtlsCoapSession:
                         self._legacy_observe_mids[tok] = mid
                         legacy = True
                 if pending:
+                    # The optionless equivalent of the branch above: the
+                    # first plain 2.05 on this token answers the register
+                    # CON, even though the relation stays probationary
+                    # until a later different-MID packet promotes it.
+                    registration = True
                     logger.debug(
                         "observe %s: probationary 2.05 without Observe option",
                         href,
@@ -1377,7 +1443,13 @@ class DtlsCoapSession:
             # block past the first) goes to the refetch worker instead.
             if blockwise_refetch:
                 self._queue_refetch(
-                    href, tuple(observe_query), legacy=legacy)
+                    href, tuple(observe_query), legacy=legacy,
+                    registration=registration)
+                return
+            if self._deliver_observation(
+                    href, payload, tuple(observe_query),
+                    registration=registration, sequence=sequence,
+                    legacy=legacy):
                 return
             cb = (
                 self.on_legacy_notification
@@ -1405,7 +1477,28 @@ class DtlsCoapSession:
         without also turning on every per-block retransmit line."""
         (logger.info if DEBUG_BRIDGE else logger.debug)(msg, *args)
 
-    def _queue_refetch(self, href, query=(), *, legacy=False):
+    def _deliver_observation(self, href, payload, query, *,
+                             registration, sequence, legacy):
+        """Hand one observation to the rich callback, if one is set.
+
+        Returns True when it took the delivery, so the two call sites
+        fall through to the (href, payload) callbacks only when no
+        consumer asked for the full relation context.
+        """
+        cb = self.on_observe_delivery
+        if cb is None:
+            return False
+        try:
+            cb(ObserveDelivery(
+                href=href, payload=payload, query=tuple(query),
+                registration=registration, sequence=sequence,
+                legacy=legacy))
+        except Exception as e:
+            logger.warning("observe delivery callback %s: %s", href, e)
+        return True
+
+    def _queue_refetch(self, href, query=(), *, legacy=False,
+                       registration=False):
         """Queue a blockwise notification for re-reading.
 
         Called from the reader thread, so it must not block: _dispatch_coap
@@ -1422,7 +1515,10 @@ class DtlsCoapSession:
                     href, len(self._refetch_pending))
                 return
             self._refetch_seq += 1
-            self._refetch_pending[key] = self._refetch_seq
+            # Latest wins, and a real change superseding the registration
+            # answer means what finally gets delivered is that change.
+            self._refetch_pending[key] = (self._refetch_seq,
+                                          bool(registration))
             self._refetch_cond.notify()
         self._start_refetch_worker()
 
@@ -1452,9 +1548,10 @@ class DtlsCoapSession:
                     self._refetch_cond.wait(1.0)
                 if not self._refetch_pending:
                     return
-                key, seq = next(iter(self._refetch_pending.items()))
+                key, (seq, registration) = next(
+                    iter(self._refetch_pending.items()))
                 del self._refetch_pending[key]
-            self._refetch_one(key, seq)
+            self._refetch_one(key, seq, registration)
 
     def _refetch_alive(self):
         """False once the session is closing or the reader has died. A
@@ -1464,7 +1561,7 @@ class DtlsCoapSession:
             return False
         return self._reader_thread is None or self._reader_running.is_set()
 
-    def _refetch_one(self, key, seq):
+    def _refetch_one(self, key, seq, registration=False):
         """Re-read one href from block 0 and deliver it if it is still
         the freshest thing we know about that resource."""
         href, query, legacy = key
@@ -1488,7 +1585,7 @@ class DtlsCoapSession:
         with self._refetch_cond:
             # A newer notification landed while we were reading. That one
             # has its own refetch queued, so this result is already stale.
-            if self._refetch_pending.get(key, 0) > seq:
+            if self._refetch_pending.get(key, (0, False))[0] > seq:
                 self._log_refetch(
                     "refetch %s tok=%s blocks=%d bytes=%d superseded",
                     href, tok.hex(), blocks, len(payload))
@@ -1497,6 +1594,11 @@ class DtlsCoapSession:
             return
         self._log_refetch("refetch %s tok=%s blocks=%d bytes=%d ok",
                           href, tok.hex(), blocks, len(payload))
+        if self._deliver_observation(
+                href, payload, query, registration=registration,
+                sequence=self._observe_sequence_for(href, query),
+                legacy=legacy):
+            return
         cb = (
             self.on_legacy_notification
             if legacy and self.on_legacy_notification is not None

--- a/tests/test_bridge_push_active.py
+++ b/tests/test_bridge_push_active.py
@@ -1,0 +1,122 @@
+"""Push Active must mean the appliance chose to send something (#41).
+
+A device answers every OBSERVE register CON with a 2.05 carrying the
+current representation, and that answer arrives on the observe token
+exactly as a spontaneous notification does. At session start the cache
+is empty, so every one of those answers is a cache change -- which used
+to set the same "something pushed recently" timestamp a real
+notification sets. The result was Push Active reading online for its
+whole ten-minute window on an appliance with no route to Samsung's
+cloud, which is emitting nothing at all.
+
+The session resolves the token, the Message ID and the Observe option,
+so it is the only layer that can tell the two apart. The bridge reads
+`ObserveDelivery.registration` rather than inferring anything.
+"""
+import threading
+import types
+
+import cbor2
+
+from mqtt_demo.bridge import PushBridge
+from smartthings_local.ocf.state_cache import StateCache
+from smartthings_local.protocol.dtls_session import ObserveDelivery
+
+HREF = '/operational/state/vs/0'
+
+
+def _bridge():
+    """A bridge reduced to its cache plumbing, with nothing that needs a
+    socket, an MQTT client or a descriptor."""
+    bridge = object.__new__(PushBridge)
+    bridge.descriptor = types.SimpleNamespace(
+        on_observation=None,
+        observe_paths=(),
+    )
+    bridge.notif_count = 0
+    bridge.last_change_ts = None
+    bridge._last_change_source = None
+    bridge._last_observe_change_ts = None
+    bridge._fetch_lock = threading.Lock()
+    bridge._fetch_gen = {}
+    bridge.maybe_publish_state = lambda **kwargs: None
+    bridge.cache = StateCache(bridge.descriptor)
+    bridge.cache.set_on_change(bridge._on_cache_change)
+    return bridge
+
+
+def _deliver(bridge, *, registration, href=HREF, query=(), **fields):
+    bridge._on_observe_delivery(ObserveDelivery(
+        href=href,
+        payload=cbor2.dumps(fields),
+        query=query,
+        registration=registration,
+    ))
+
+
+def test_registration_answer_does_not_count_as_push():
+    bridge = _bridge()
+
+    _deliver(bridge, registration=True, state='Ready')
+
+    # The cache took the payload -- that part is load-bearing, since both
+    # sides seed from this first representation.
+    assert bridge.cache.get(HREF) == {'state': 'Ready'}
+    assert bridge.notif_count == 1
+    # ...but it is not evidence of push.
+    assert bridge._last_observe_change_ts is None
+    assert bridge.cache.source[HREF] == 'observe-register'
+
+
+def test_a_change_the_device_chose_to_send_does_count():
+    bridge = _bridge()
+
+    _deliver(bridge, registration=True, state='Ready')
+    _deliver(bridge, registration=False, state='Running')
+
+    assert bridge._last_observe_change_ts is not None
+    assert bridge.cache.source[HREF] == 'observe'
+
+
+def test_query_variants_each_get_their_own_registration_answer():
+    """Two query-qualified relations on one href register separately, so
+    both answers arrive and neither is push. Position alone cannot tell
+    them apart, because the href is the same for both."""
+    bridge = _bridge()
+
+    _deliver(bridge, registration=True, query=('if=oic.if.a',), state='Ready')
+    _deliver(bridge, registration=True, query=('if=oic.if.s',), state='Ready')
+
+    assert bridge._last_observe_change_ts is None
+    assert bridge.cache.source[HREF] == 'observe-register'
+
+
+def test_a_reconnect_re_registers_and_that_is_still_not_push():
+    """Reconnects and the 6-hourly refresh both retire the token and
+    subscribe again, so the answers come round again. The session marks
+    each one, and the bridge keeps no per-session state of its own."""
+    bridge = _bridge()
+
+    _deliver(bridge, registration=True, state='Ready')
+    _deliver(bridge, registration=False, state='Running')
+    bridge._last_observe_change_ts = None
+
+    _deliver(bridge, registration=True, state='Ready')
+
+    assert bridge._last_observe_change_ts is None
+    assert bridge.cache.source[HREF] == 'observe-register'
+
+
+def test_a_blockwise_registration_answer_stays_a_registration():
+    """An empty or partial payload goes out to a fetchback thread, and
+    the re-read must not launder the registration answer into a push."""
+    bridge = _bridge()
+    scheduled = []
+    bridge._schedule_fetchback = (
+        lambda href, delay_s=0.0, source='observe':
+        scheduled.append((href, source)))
+
+    bridge._on_observe_delivery(ObserveDelivery(
+        href=HREF, payload=b'', registration=True))
+
+    assert scheduled == [(HREF, 'observe-register')]

--- a/tests/test_handshake_alert_logging.py
+++ b/tests/test_handshake_alert_logging.py
@@ -1,0 +1,97 @@
+"""A handshake that dies at the TLS layer must say why, in the log only.
+
+`connect()` turns any `SSL.Error` into a bare `SessionError`, whose
+message is the class default. That is deliberate -- the errors module
+refuses arbitrary detail because backend errors can carry remote
+endpoints, local paths or credential metadata -- but it left the alert
+itself unrecoverable, so a rejected handshake read as "session
+operation failed" and nothing more.
+
+The alert now reaches the local log. These tests pin both halves: the
+reason survives, and the raised exception stays redacted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from OpenSSL import SSL
+
+from smartthings_local.errors import SessionError
+from smartthings_local.protocol.dtls_session import _openssl_error_reasons
+
+
+def test_a_peer_alert_is_named():
+    error = SSL.Error([("SSL routines", "", "tlsv1 alert unknown ca")])
+
+    assert _openssl_error_reasons(error) == "tlsv1 alert unknown ca"
+
+
+def test_several_stacked_reasons_are_all_kept():
+    error = SSL.Error([
+        ("SSL routines", "ssl3_read_bytes", "sslv3 alert handshake failure"),
+        ("SSL routines", "ssl3_get_record", "wrong version number"),
+    ])
+
+    assert _openssl_error_reasons(error) == (
+        "sslv3 alert handshake failure, wrong version number"
+    )
+
+
+def test_a_syscall_error_keeps_its_string_and_drops_the_errno():
+    assert _openssl_error_reasons(
+        SSL.SysCallError(-1, "Unexpected EOF")) == "Unexpected EOF"
+
+
+def test_an_empty_error_falls_back_to_its_type():
+    assert _openssl_error_reasons(SSL.Error()) == "Error"
+    assert _openssl_error_reasons(SSL.SysCallError()) == "SysCallError"
+
+
+def test_nothing_but_reason_strings_survives():
+    """The guard that keeps this inside the redaction contract: a host,
+    a filesystem path or a key blob in the args is not a reason string
+    and must not be echoed."""
+    error = SSL.Error([
+        ("SSL routines", "/etc/ssl/private/client.key", "bad decrypt"),
+    ])
+
+    reasons = _openssl_error_reasons(error)
+    assert reasons == "bad decrypt"
+    assert "/etc/ssl" not in reasons
+
+
+def test_the_raised_error_stays_redacted():
+    """Detail goes to the log, never onto the exception a consumer may
+    surface or a reporter may paste into an issue."""
+    assert str(SessionError()) == "session operation failed"
+    assert SessionError().args == ("session operation failed",)
+
+
+class _NullAuth:
+    def configure_context(self, _context):
+        return None
+
+
+def test_connect_logs_the_alert_and_still_raises_a_redacted_error(
+    caplog, monkeypatch
+):
+    """The whole point, end to end: drive connect() into the SSL.Error
+    branch and check the alert lands in the log while the exception the
+    caller sees carries nothing."""
+    from smartthings_local.protocol import dtls_session
+
+    def reject(*_args, **_kwargs):
+        raise SSL.Error([("SSL routines", "", "tlsv1 alert unknown ca")])
+
+    monkeypatch.setattr(dtls_session, "_drive_dtls_handshake", reject)
+    session = dtls_session.DtlsCoapSession(
+        "127.0.0.1", 49155, auth=_NullAuth())
+
+    with caplog.at_level(logging.WARNING, logger=dtls_session.__name__):
+        with pytest.raises(SessionError) as raised:
+            session.connect(timeout=1.0)
+
+    assert "tlsv1 alert unknown ca" in caplog.text
+    assert str(raised.value) == "session operation failed"

--- a/tests/test_observe_delivery.py
+++ b/tests/test_observe_delivery.py
@@ -1,0 +1,181 @@
+"""Full relation context on each Observe delivery.
+
+`on_notification(href, payload)` cannot express two things the session
+already knows. Which delivery answered the register CON -- RFC 7641
+§3.2 makes it the first response on the token, and a consumer that
+treats it as a push reports a device as pushing when it has only
+replied to being asked (#41). And which query-qualified relation it
+belongs to, since one href can carry several, each registering on its
+own token.
+
+`on_observe_delivery` carries both, so a consumer reads a fact instead
+of reconstructing one from arrival order.
+"""
+
+from __future__ import annotations
+
+from smartthings_local.protocol.coap import (
+    BLOCK2,
+    OBSERVE,
+    TYPE_NON,
+    block_value,
+    build_coap,
+)
+from smartthings_local.protocol.dtls_session import (
+    DtlsCoapSession,
+    ObserveDelivery,
+)
+
+
+class _NullAuth:
+    def configure_context(self, _context):
+        return None
+
+
+def _session(**callbacks):
+    session = DtlsCoapSession(
+        "device.example",
+        5684,
+        auth=_NullAuth(),
+        rate_limit_rps=1_000_000,
+        **callbacks,
+    )
+    session.conn = object()
+    session._send_dgram = lambda _datagram: None
+    return session
+
+
+def _observe_value(value):
+    if value == 0:
+        return b""
+    return value.to_bytes((value.bit_length() + 7) // 8, "big")
+
+
+def _notify(session, token, mid, payload, *, sequence=None, options=()):
+    observe_options = (
+        () if sequence is None else ((OBSERVE, _observe_value(sequence)),)
+    )
+    session._dispatch_coap(
+        build_coap(TYPE_NON, 0x45, mid, token,
+                   (*observe_options, *options), payload)
+    )
+
+
+def test_the_first_response_on_a_token_is_the_registration_answer():
+    seen: list[ObserveDelivery] = []
+    session = _session(on_observe_delivery=seen.append)
+    token = session.subscribe(["operational", "state", "vs", "0"])
+
+    _notify(session, token, 10, b"first", sequence=1)
+    _notify(session, token, 11, b"second", sequence=2)
+
+    assert [d.registration for d in seen] == [True, False]
+    assert [d.sequence for d in seen] == [1, 2]
+    assert [d.payload for d in seen] == [b"first", b"second"]
+    assert all(d.href == "/operational/state/vs/0" for d in seen)
+
+
+def test_each_query_variant_registers_on_its_own_token():
+    """The case arrival order cannot resolve: two relations on one href,
+    so the second registration answer looks like the first relation's
+    second notification unless the query is carried through."""
+    seen: list[ObserveDelivery] = []
+    session = _session(on_observe_delivery=seen.append)
+    actuator = session.subscribe(["mode", "vs", "0"], query=("if=oic.if.a",))
+    sensor = session.subscribe(["mode", "vs", "0"], query=("if=oic.if.s",))
+
+    _notify(session, actuator, 10, b"a", sequence=1)
+    _notify(session, sensor, 11, b"s", sequence=1)
+
+    assert [d.registration for d in seen] == [True, True]
+    assert [d.query for d in seen] == [("if=oic.if.a",), ("if=oic.if.s",)]
+
+
+def test_re_subscribing_marks_the_new_answer_as_a_registration():
+    """Retiring a token clears its recorded sequence, so a reconnect or
+    the periodic refresh is recognised with no caller bookkeeping."""
+    seen: list[ObserveDelivery] = []
+    session = _session(on_observe_delivery=seen.append)
+    first = session.subscribe(["power", "vs", "0"])
+    _notify(session, first, 10, b"on", sequence=1)
+    _notify(session, first, 11, b"off", sequence=2)
+
+    session.unsubscribe(["power", "vs", "0"])
+    second = session.subscribe(["power", "vs", "0"])
+    _notify(session, second, 12, b"on", sequence=1)
+
+    assert [d.registration for d in seen] == [True, False, True]
+
+
+def test_an_optionless_initial_response_is_also_a_registration():
+    """Firmware that omits the Observe option still answers the register
+    CON, and that answer is no more a push than a compliant one."""
+    seen: list[ObserveDelivery] = []
+    pending: list[str] = []
+    session = _session(on_observe_delivery=seen.append,
+                       on_observe_pending=pending.append)
+    token = session.subscribe(["alarms", "vs", "0"])
+
+    _notify(session, token, 10, b"first")
+    _notify(session, token, 11, b"second")
+
+    assert pending == ["/alarms/vs/0"]
+    assert [d.registration for d in seen] == [True, False]
+    assert [d.sequence for d in seen] == [None, None]
+    assert [d.legacy for d in seen] == [False, True]
+
+
+def test_a_blockwise_registration_answer_survives_the_refetch():
+    """The re-read is what reaches the caller, so the flag has to travel
+    with the queued relation rather than with the first block."""
+    seen: list[ObserveDelivery] = []
+    session = _session(on_observe_delivery=seen.append)
+    token = session.subscribe(["mode", "vs", "0"])
+    queued = []
+    session._queue_refetch = (
+        lambda href, query=(), *, legacy=False, registration=False:
+        queued.append((href, query, legacy, registration)))
+
+    _notify(session, token, 10, b"partial", sequence=1,
+            options=((BLOCK2, block_value(0, 1, 6)),))
+
+    assert queued == [("/mode/vs/0", (), False, True)]
+    assert seen == []
+
+
+def test_the_rich_callback_replaces_the_plain_one():
+    """Both firing would double-apply every representation."""
+    rich: list[ObserveDelivery] = []
+    plain = []
+    session = _session(on_observe_delivery=rich.append,
+                       on_notification=lambda h, p: plain.append((h, p)))
+    token = session.subscribe(["power", "vs", "0"])
+
+    _notify(session, token, 10, b"on", sequence=1)
+
+    assert len(rich) == 1
+    assert plain == []
+
+
+def test_existing_callers_are_untouched():
+    """The default stays exactly what it was: no delivery callback set,
+    so on_notification keeps receiving every representation."""
+    plain = []
+    session = _session(on_notification=lambda h, p: plain.append((h, p)))
+    token = session.subscribe(["power", "vs", "0"])
+
+    _notify(session, token, 10, b"on", sequence=1)
+    _notify(session, token, 11, b"off", sequence=2)
+
+    assert plain == [("/power/vs/0", b"on"), ("/power/vs/0", b"off")]
+
+
+def test_a_raising_callback_does_not_kill_the_reader():
+    def explode(_delivery):
+        raise RuntimeError("consumer bug")
+
+    session = _session(on_observe_delivery=explode)
+    token = session.subscribe(["power", "vs", "0"])
+
+    _notify(session, token, 10, b"on", sequence=1)
+    _notify(session, token, 11, b"off", sequence=2)

--- a/tests/test_observe_relations.py
+++ b/tests/test_observe_relations.py
@@ -184,6 +184,7 @@ def test_probationary_blockwise_initial_queues_refetch_without_partial_delivery(
         "/mode/vs/0",
         ("if=oic.if.a",),
         legacy=False,
+        registration=True,
     )
 
 

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -20,6 +20,7 @@ from smartthings_local.protocol.auth import (
 from smartthings_local.protocol.dtls_session import (
     ConnectCancellation,
     DtlsCoapSession,
+    ObserveDelivery,
 )
 from smartthings_local.protocol.ocf_discovery import (
     OcfSecurePortDiscoveryResult,
@@ -65,6 +66,7 @@ SUPPORTED_DOWNSTREAM_IMPORTS = {
     "smartthings_local.protocol.dtls_session": (
         "ConnectCancellation",
         "DtlsCoapSession",
+        "ObserveDelivery",
     ),
     "smartthings_local.protocol.dtls_probe": (
         "ALERT",
@@ -230,10 +232,23 @@ def test_dtls_session_constructor_keeps_file_memory_and_local_port_inputs():
         "on_legacy_notification",
         "on_observe_pending",
         "on_observe_error",
+        "on_observe_delivery",
     ):
         parameter = inspect.signature(DtlsCoapSession).parameters[callback]
         assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
         assert parameter.default is None
+
+
+def test_observe_delivery_carries_the_full_relation_context():
+    """Consumers key on (href, query) and act on `registration`, so both
+    have to stay on the record even as fields are added."""
+    delivery = ObserveDelivery(href="/power/vs/0", payload=b"on")
+    assert delivery.query == ()
+    assert delivery.registration is False
+    assert delivery.sequence is None
+    assert delivery.legacy is False
+    assert {"href", "payload", "query", "registration", "sequence",
+            "legacy"} <= set(ObserveDelivery.__dataclass_fields__)
 
 
 def test_known_host_multicast_discovery_has_a_bounded_explicit_interface_api():


### PR DESCRIPTION
Two commits. The first closes #41, the second came out of validating it on hardware.

## Registration answers are not pushes (#41)

`Push Active` went online for its full ten-minute window on every connect, including on an appliance with no route to Samsung's cloud that emits nothing. The cause is that a device answers every register CON with the current representation, and that answer reaches `on_notification` exactly as a spontaneous notification does.

RFC 7641 §3.2 makes the first response on a token the answer to the registration, and the session already resolves the token, the Message ID and the Observe option. None of it reaches a caller, because `on_notification` carries `(href, payload)` alone. A consumer can only infer from arrival order, and that inference breaks on an href carrying several query-qualified relations, since both answers look alike.

`ObserveDelivery` carries the relation context and `on_observe_delivery` receives it, taking precedence over `on_notification` and `on_legacy_notification` so a representation is still delivered once. The flag travels with a queued blockwise relation, so a re-read stays a registration answer. Retiring a token clears its recorded sequence, so a reconnect or the 6-hourly refresh registers afresh with nothing tracked in the caller.

Additive and keyword-only. The callback defaults to `None` and existing consumers keep receiving every representation through `on_notification`, which a test pins.

## Name the alert when a handshake fails

`connect()` turned every `SSL.Error` into a bare `SessionError` and dropped the exception, so a rejected handshake read as `session operation failed` and nothing more. One reference appliance did exactly that during a deploy and recovered on its own retry, with the alert already gone.

The redaction stays, because it is deliberate: the errors module refuses arbitrary detail since backend errors can carry remote endpoints, local paths or credential metadata. The alert goes to the local log instead, narrowed to the reason strings OpenSSL recorded. A path or host in another slot of the reason tuple is dropped, which a test pins. The raised `SessionError` is unchanged.

This is also the artefact I keep asking reporters for in #16 and #20.

## Validation

739 tests pass, and the first commit passes alone at 732 for bisect. Each new behaviour is mutation-checked: reverting the registration flag, the optionless case, its survival across a blockwise refetch, and the log line each fail exactly the test written for them.

On hardware, against my oven and dryer. The previous build put both appliances online 55s after connect and held them for the full window. This one logged no `push_active` online event across 35 minutes, with both units at 0 err, 0 ping-fail and 0 timeouts, and no state change sourced from observe at all.

The handshake failure did not reproduce across a graceful restart, a rebuild and recreate, or a SIGKILL with no close_notify. The SIGKILL case settles something else in passing: a bridge killed dead, leaving an orphaned association on the device, re-handshaked on the same 5-tuple and was accepted first time on both appliances. That is the RFC 6347 §4.2.8 behaviour the fixed local port depends on, checked before only on the oven. So the cause of the original rejection is still open, and the logging is there to name it next time.


https://claude.ai/code/session_018zWZfikEW9X1RVyadNZD3C
