### PR TITLE
Sync the appliance clock from the bridge host

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ Notes specific to this firmware family:
 | `CERT_PATH` / `KEY_PATH` | Override cert lookup (auto-detects `/config/` then `./certs/`) |
 | `HEALTH_INTERVAL_S` | Seconds between `<prefix>/bridge/health` publishes (default 60) |
 | `PING_INTERVAL_S` | CoAP empty-CON ping cadence; three consecutive failures publish `availability=offline` (default 25). Tier polling cadences are descriptor-declared, not env-tunable. |
+| `CLOCK_SYNC_INTERVAL_H` | Hours between appliance clock writes, for descriptors that declare one (default 24; `0` disables the sync and its button) |
 | `SSH_HOST` / `REMOTE_DIR` / `APPDATA_DIR` | Used by `deploy.sh` only |
 
 ### MQTT topics — outgoing (bridge → broker)
@@ -1024,6 +1025,17 @@ Oven:
 | `cmd/setpoint` | Integer °C (30–270, step 5) | RMW of `/temperatures/vs/0 .items[0].desired`; requires RC |
 | `cmd/mode` | Mode name (e.g. `Convection`, `LargeGrill`) | POST `/mode/vs/0 {modes: [<name>]}`; requires RC |
 | `cmd/stop` | (button press) | POST `/operational/state/vs/0 {state: Ready}` |
+| `cmd/sync_clock` | (button press) | POST `/configuration/vs/0 {x.com.samsung.da.currentTime: <host local time>}` |
+
+#### Clock sync
+
+An appliance kept off the internet has no way to correct its own clock, so the display drifts. Where a descriptor declares a `ClockSync` spec (today the oven), the bridge writes the host's local wall clock to `/configuration/vs/0` as `x.com.samsung.da.currentTime` every `CLOCK_SYNC_INTERVAL_H` hours, and exposes a Sync clock button for an immediate write. Set `CLOCK_SYNC_INTERVAL_H=0` to switch off both.
+
+The field is write-only: a GET of that resource returns the metadata without it, so the value never enters the state cache and no sensor reports it. Timestamps land in the container's `TZ`.
+
+The write came from LocalThings [#404](https://github.com/mbillow/localthings/issues/404) / [#428](https://github.com/mbillow/localthings/pull/428), verified there on a TP1X range and originally documented on [the SmartThings forum](https://community.smartthings.com/t/samsung-oven-range-and-cooktop-sync-time-api/251391). Both the periodic write and the button answer 2.04 on the oven this repo's sample descriptor targets. Other appliance classes are untested — a rejection shows up as a 4.xx in the bridge log, and nothing else is written to the resource.
+
+One limit is worth knowing whatever the appliance. A timestamp far outside its certificate validity window can break certificate verification and leave it unresponsive, so the bridge refuses to write a host clock reading outside `PLAUSIBLE_FROM`/`PLAUSIBLE_UNTIL` in `mqtt_demo/clock_sync.py`. A host that boots without NTP skips the sync rather than writing 1970.
 
 ### Entity counts (approximate, per appliance)
 
@@ -1035,7 +1047,7 @@ Oven:
 | `light` | — | 1 (lamp) |
 | `number` | — | 1 (setpoint slider) |
 | `select` | 1 (course) | 1 (mode) |
-| `button` | 3 (start/pause/stop) | 1 (stop) |
+| `button` | 3 (start/pause/stop) | 2 (stop, sync clock) |
 
 Gated control entities use HA's `availability_mode: all` against `<prefix>/availability` AND `<prefix>/remote_available`. Flip Remote Control on the appliance's front panel and those entities un-grey in HA.
 
@@ -1067,6 +1079,7 @@ mqtt_demo/                           MQTT bridge demo (consumes smartthings_loca
   logger.py                          Tagged logger helpers
   bridge.py                          Bridge — one DTLS session per appliance, descriptor-driven
   descriptor.py                      ApplianceDescriptor dataclass + HA discovery helpers
+  clock_sync.py                      Periodic appliance clock write (write-only resource, host-clock gated)
   samples/
     __init__.py                      Sample DESCRIPTORS registry (frozen reference implementations)
     dryer.py                         Dryer descriptor (paths, flatten, discovery, commands)

--- a/mqtt_demo/.env.example
+++ b/mqtt_demo/.env.example
@@ -65,7 +65,18 @@ PING_INTERVAL_S=25
 # is unverified on Samsung's RT-OCF.
 WRITE_MAX_ATTEMPTS=1
 
-# Container TZ.
+# Appliance clock sync. An appliance kept off the internet cannot
+# correct its own clock, so its display drifts. Where the descriptor
+# declares a clock resource (oven today), the bridge writes the host's
+# local wall clock to /configuration/vs/0 every CLOCK_SYNC_INTERVAL_H
+# hours, and a Sync clock button does it on demand. 0 disables both.
+# The bridge refuses to write an implausible host clock: a timestamp
+# outside the appliance's certificate validity window can break its
+# certificate verification and leave it unresponsive.
+CLOCK_SYNC_INTERVAL_H=24
+
+# Container TZ. Also the timezone written to the appliance clock by
+# the sync above, since the appliance takes a local wall-clock string.
 TZ=Europe/London
 
 

--- a/mqtt_demo/bridge.py
+++ b/mqtt_demo/bridge.py
@@ -35,8 +35,13 @@ from smartthings_local.protocol.dtls_probe import (
 from smartthings_local.protocol.coap import fmt_code
 from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
+from .clock_sync import ClockSyncTask
 from .config import ApplianceConfig, SharedConfig
-from .descriptor import ApplianceDescriptor, bridge_diagnostic_discovery
+from .descriptor import (
+    ApplianceDescriptor,
+    bridge_diagnostic_discovery,
+    clock_sync_discovery,
+)
 from .logger import bridge_logger
 
 DEBUG_BRIDGE = os.environ.get('DEBUG_BRIDGE') == '1'
@@ -63,6 +68,12 @@ UNREACHABLE_RECONNECT_S = 120.0
 # recovers, since nothing triggers a fresh subscribe on the existing
 # session.
 OBSERVE_REFRESH_INTERVAL_S = 6 * 3600.0
+
+# MQTT command suffix for an on-demand clock sync. Handled by the bridge
+# rather than a descriptor command handler: the clock resource is
+# write-only, so it must skip the optimistic cache merge every other
+# command gets (see handle_command).
+CMD_SYNC_CLOCK = 'cmd/sync_clock'
 
 # Base for the fixed DTLS source port; each appliance binds base+index so
 # every reconnect uses the same 5-tuple. If the bridge dies without
@@ -116,6 +127,14 @@ class PushBridge:
         self.scheduler: PollScheduler | None = None
         self.keepalive: KeepaliveTask | None = None
         self.observe_refresh: ObserveRefreshTask | None = None
+        self.clock_sync: ClockSyncTask | None = None
+
+        # Clock sync survives reconnects: the task is session-scoped but
+        # the schedule is not, so a bridge that reconnects often still
+        # writes the clock on the configured interval.
+        self.clock_sync_enabled = (descriptor.clock_sync is not None
+                                   and shared.CLOCK_SYNC_INTERVAL_H > 0)
+        self._last_clock_sync_ts: float | None = None
 
         self.cache = StateCache(descriptor)
         self.cache.set_on_change(self._on_cache_change)
@@ -178,6 +197,10 @@ class PushBridge:
             + bridge_diagnostic_discovery(
                 app.topic_prefix, shared.HA_DISCOVERY_PREFIX, app.device_name,
                 model=descriptor.name.title()))
+        if self.clock_sync_enabled:
+            self.discovery_payloads += clock_sync_discovery(
+                app.topic_prefix, shared.HA_DISCOVERY_PREFIX, app.device_name,
+                model=descriptor.name.title(), cmd_suffix=CMD_SYNC_CLOCK)
 
     def request_stop(self) -> None:
         """Stop the bridge and wake workers belonging to its current session."""
@@ -444,9 +467,12 @@ class PushBridge:
             interval_s=OBSERVE_REFRESH_INTERVAL_S,
             logger=self.log,
         )
+        clock_sync = self._build_clock_sync(sess)
+
         self.scheduler = scheduler
         self.keepalive = keepalive
         self.observe_refresh = observe_refresh
+        self.clock_sync = clock_sync
 
         # These workers belong to this DTLS session, not to the bridge
         # process. A reconnect must retire them before the replacement
@@ -469,7 +495,11 @@ class PushBridge:
         ref_t = threading.Thread(
             target=observe_refresh.run_forever, args=(session_stop,),
             daemon=True, name=f'{self.app.klass}-obsref')
-        workers = (sched_t, ka_t, ref_t)
+        workers = [sched_t, ka_t, ref_t]
+        if clock_sync is not None:
+            workers.append(threading.Thread(
+                target=clock_sync.run_forever, args=(session_stop,),
+                daemon=True, name=f'{self.app.klass}-clock'))
         started_workers = []
 
         try:
@@ -493,9 +523,34 @@ class PushBridge:
             self.scheduler = None
             self.keepalive = None
             self.observe_refresh = None
+            self.clock_sync = None
             with self._session_stop_lock:
                 if self._session_stop is session_stop:
                     self._session_stop = None
+
+    def _build_clock_sync(self, sess) -> ClockSyncTask | None:
+        """Clock-sync task for this session, or None.
+
+        Called after the seed so the capability check reads the links
+        the appliance actually reported: a device in the class that does
+        not carry the clock resource never gets written to."""
+        if not self.clock_sync_enabled:
+            return None
+        spec = self.descriptor.clock_sync
+        if spec.requires_href not in self.cache.links:
+            self.log.info("clock sync off: %s absent from this device",
+                          spec.requires_href)
+            return None
+        return ClockSyncTask(
+            sess, spec.path_segs, spec.field,
+            interval_s=self.shared.CLOCK_SYNC_INTERVAL_H * 3600.0,
+            logger=self.log,
+            last_sync_ts=self._last_clock_sync_ts,
+            on_sync=self._note_clock_sync,
+        )
+
+    def _note_clock_sync(self, ts: float) -> None:
+        self._last_clock_sync_ts = ts
 
     def _seed_from_device0(self, sess):
         code, pl = sess.get(self.descriptor.seed_path, timeout=15.0)
@@ -688,6 +743,9 @@ class PushBridge:
         if not topic.startswith(self.cmd_topic_prefix):
             return
         suffix = topic[len(self.cmd_topic_prefix) - len('cmd/'):]
+        if suffix == CMD_SYNC_CLOCK:
+            self._handle_sync_clock()
+            return
         handler = self.cmd_handlers.get(suffix)
         if handler is None:
             self.log.warning("unknown command topic: %s", topic)
@@ -724,6 +782,18 @@ class PushBridge:
             # The PollScheduler will reconcile on its next tier tick
             # after the write_in_progress settle window expires.
             self.cache.apply_optimistic(href, body)
+
+    def _handle_sync_clock(self) -> None:
+        """On-demand clock write from the HA button.
+
+        Deliberately outside the descriptor command path: the clock
+        field is write-only, so it must not reach the optimistic cache
+        merge handle_command applies to normal writes."""
+        task = self.clock_sync
+        if task is None:
+            self.log.warning("sync_clock: clock sync not active")
+            return
+        task.sync_now(reason='mqtt')
 
     def publish_health(self):
         now = time.time()

--- a/mqtt_demo/clock_sync.py
+++ b/mqtt_demo/clock_sync.py
@@ -1,0 +1,146 @@
+"""Periodic appliance clock sync.
+
+Samsung appliances keep their own wall clock and normally correct it
+against Samsung's cloud. A bridge-only deployment blocks that path, so
+the display clock free-runs and drifts. The appliance exposes the clock
+as a write on `/configuration/vs/0`:
+
+    {'x.com.samsung.da.currentTime': '2026-09-08T14:30:00'}
+
+The field is write-only. A GET of that resource returns the resource
+metadata without it, which is why no device-tree dump carries the name
+and why the bridge never puts the value in its cache -- there is nothing
+the appliance can ever confirm it with. Verified on hardware, a TP1X
+range, in LocalThings #404 / #428; the vendor field itself was first
+documented on the SmartThings community forum:
+https://community.smartthings.com/t/samsung-oven-range-and-cooktop-sync-time-api/251391
+
+The timestamp is the host's LOCAL wall clock, no timezone suffix, so the
+container's TZ is what lands on the appliance display.
+
+Both that forum thread and LocalThings warn that a timestamp far outside
+the appliance's certificate validity window can break its certificate
+verification and leave it unresponsive. A host whose own clock is wrong
+would write exactly such a value, so `PLAUSIBLE_FROM`/`PLAUSIBLE_UNTIL`
+gate every write: an unsynced host clock skips the sync instead of
+bricking the appliance.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime
+from typing import Callable, Optional
+
+import cbor2
+
+from smartthings_local.protocol.coap import fmt_code
+from smartthings_local.protocol.dtls_session import DtlsCoapSession
+
+# Wire format the appliance accepts: local wall clock, second precision,
+# no offset and no 'Z'.
+TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
+# Host-clock sanity gate. A container that came up before its NTP sync
+# lands (or with no RTC at all) reports a date well before this floor;
+# writing that to the appliance is the failure mode the forum thread
+# warns about. The ceiling catches the same fault in the other
+# direction.
+PLAUSIBLE_FROM  = datetime(2026, 1, 1)
+PLAUSIBLE_UNTIL = datetime(2046, 1, 1)
+
+# Delay before the first sync of a session. Keeps the write clear of the
+# seed + discovery burst on connect.
+INITIAL_DELAY_S = 15.0
+
+WRITE_TIMEOUT_S = 8.0
+
+
+class ClockSyncTask:
+    """Writes the host's local wall clock to the appliance periodically.
+
+    Session-scoped, like KeepaliveTask and ObserveRefreshTask, but the
+    schedule is not: `last_sync_ts` carries the previous session's last
+    successful write in, and `on_sync` reports each one back out. A
+    bridge that reconnects every few minutes therefore still syncs on
+    the requested interval rather than once per reconnect.
+    """
+
+    def __init__(self,
+                 session: DtlsCoapSession,
+                 path_segs,
+                 field: str,
+                 interval_s: float,
+                 logger=None,
+                 last_sync_ts: Optional[float] = None,
+                 on_sync: Optional[Callable[[float], None]] = None,
+                 now_fn: Callable[[], datetime] = datetime.now):
+        self.session = session
+        self.path_segs = list(path_segs)
+        self.field = field
+        self.interval_s = interval_s
+        self.log = logger
+        self.last_sync_ts = last_sync_ts
+        self.on_sync = on_sync
+        self.now_fn = now_fn
+        self._sync_count = 0
+
+    @property
+    def sync_count(self) -> int:
+        return self._sync_count
+
+    @property
+    def href(self) -> str:
+        return '/' + '/'.join(self.path_segs)
+
+    def sync_now(self, reason: str = 'periodic') -> bool:
+        """Write the host clock once. Returns True on a 2.xx response."""
+        now = self.now_fn()
+        if not (PLAUSIBLE_FROM <= now < PLAUSIBLE_UNTIL):
+            if self.log:
+                self.log.warning(
+                    "clock sync (%s) skipped: host clock reads %s, outside "
+                    "the plausible window -- writing it could break the "
+                    "appliance's certificate verification",
+                    reason, now.strftime(TIME_FORMAT))
+            return False
+
+        stamp = now.strftime(TIME_FORMAT)
+        body = {self.field: stamp}
+        try:
+            code, _ = self.session.post(self.path_segs, cbor2.dumps(body),
+                                        timeout=WRITE_TIMEOUT_S)
+        except Exception as e:
+            if self.log:
+                self.log.warning("clock sync (%s) %s: %s",
+                                 reason, self.href, e)
+            return False
+
+        ok = code >> 5 == 2
+        if ok:
+            self._sync_count += 1
+            self.last_sync_ts = time.time()
+            if self.on_sync:
+                self.on_sync(self.last_sync_ts)
+        # The write is not cached either way: the appliance never reads
+        # the field back, so a cached copy would be state invented by the
+        # bridge rather than state the device reported.
+        if self.log:
+            log = self.log.info if ok else self.log.warning
+            log("clock sync (%s) %s = %s -> %s",
+                reason, self.href, stamp, fmt_code(code))
+        return ok
+
+    def _initial_delay(self) -> float:
+        """Seconds until the first sync of this session."""
+        if self.last_sync_ts is None:
+            return INITIAL_DELAY_S
+        due_in = self.interval_s - (time.time() - self.last_sync_ts)
+        return max(INITIAL_DELAY_S, due_in)
+
+    def run_forever(self, stop: threading.Event) -> None:
+        if stop.wait(self._initial_delay()):
+            return
+        self.sync_now()
+        while not stop.wait(self.interval_s):
+            self.sync_now()

--- a/mqtt_demo/clock_sync.py
+++ b/mqtt_demo/clock_sync.py
@@ -5,7 +5,7 @@ against Samsung's cloud. A bridge-only deployment blocks that path, so
 the display clock free-runs and drifts. The appliance exposes the clock
 as a write on `/configuration/vs/0`:
 
-    {'x.com.samsung.da.currentTime': '2026-09-08T14:30:00'}
+    {'x.com.samsung.da.currentTime': '<YYYY-MM-DD>T<HH:MM:SS>'}
 
 The field is write-only. A GET of that resource returns the resource
 metadata without it, which is why no device-tree dump carries the name

--- a/mqtt_demo/config.py
+++ b/mqtt_demo/config.py
@@ -59,6 +59,7 @@ class SharedConfig:
     HEALTH_INTERVAL_S: int
     PING_INTERVAL_S: int
     WRITE_MAX_ATTEMPTS: int
+    CLOCK_SYNC_INTERVAL_H: float
 
     @classmethod
     def from_env(cls) -> 'SharedConfig':
@@ -74,6 +75,11 @@ class SharedConfig:
             HEALTH_INTERVAL_S=int(os.getenv('HEALTH_INTERVAL_S', '60')),
             PING_INTERVAL_S=int(os.getenv('PING_INTERVAL_S', '25')),
             WRITE_MAX_ATTEMPTS=int(os.getenv('WRITE_MAX_ATTEMPTS', '1')),
+            # Hours between appliance clock writes; 0 disables the sync
+            # and its button. Only appliance classes whose descriptor
+            # declares a clock_sync spec are affected.
+            CLOCK_SYNC_INTERVAL_H=float(
+                os.getenv('CLOCK_SYNC_INTERVAL_H', '24')),
         )
 
 

--- a/mqtt_demo/descriptor.py
+++ b/mqtt_demo/descriptor.py
@@ -11,6 +11,10 @@ class (dryer, oven, …) provides a descriptor that supplies:
   * build_discovery(…)  — list of (HA-discovery topic, payload)
   * command_handlers()  — MQTT command-suffix → (path_segs, body_dict)
 
+An optional `clock_sync` spec declares the resource that sets the
+appliance's own wall clock, which the bridge then keeps in step with the
+host (mqtt_demo/clock_sync.py).
+
 Optional hooks let an appliance hold transient state across pushes:
 
   * on_observation(state, href, rep)   — capture anchors, e.g. for
@@ -28,6 +32,23 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from smartthings_local.ocf.poll_scheduler import PollTier
+
+
+@dataclass(frozen=True)
+class ClockSync:
+    """Where an appliance class takes a wall-clock write.
+
+    Samsung appliances correct their own clock against the cloud, so an
+    appliance the bridge keeps off the internet drifts. `path_segs` +
+    `field` name the write-only resource that sets it; see
+    mqtt_demo/clock_sync.py for the wire format and the host-clock
+    safety gate. `requires_href` is checked against the seeded link dict
+    before the bridge schedules anything, so a device in the class that
+    does not carry the resource is left alone."""
+
+    path_segs: list[str]
+    field: str
+    requires_href: str
 
 
 @dataclass
@@ -81,6 +102,11 @@ class ApplianceDescriptor:
     # local-tools/probe_poll_rate_combined.py (dryer ~14 req/s, oven
     # ~8 req/s) inform the defaults each descriptor sets.
     poll_tiers: list['PollTier'] = field(default_factory=list)
+
+    # Set when the appliance class exposes a writable clock. The bridge
+    # then runs a periodic sync (CLOCK_SYNC_INTERVAL_H) and offers a
+    # `cmd/sync_clock` button; unset leaves both out entirely.
+    clock_sync: Optional['ClockSync'] = None
 
     # Predicate the PollScheduler calls each tick to decide whether to
     # use a tier's active_interval_s. Gets a shallow snapshot of the
@@ -226,3 +252,30 @@ def bridge_diagnostic_discovery(topic_prefix: str,
                "{{ value_json.last_observe_age_s if value_json.last_observe_age_s is not none else 'never' }}",
                icon='mdi:radar'),
     ]
+
+
+def clock_sync_discovery(topic_prefix: str,
+                         ha_discovery_prefix: str,
+                         device_name: str,
+                         model: str,
+                         cmd_suffix: str = 'cmd/sync_clock') -> list[tuple[str, bytes]]:
+    """HA-discovery payload for the Sync clock button.
+
+    Config-category, no state topic: the appliance never reads the clock
+    field back, so there is nothing to show. Appended by the bridge when
+    the descriptor declares a clock_sync spec and the interval knob
+    leaves the feature on."""
+    cfg = {
+        'name':            'Sync clock',
+        'unique_id':       f"{topic_prefix}_sync_clock",
+        'object_id':       f"{topic_prefix}_sync_clock",
+        'command_topic':   f"{topic_prefix}/{cmd_suffix}",
+        'payload_press':   'Sync',
+        'icon':            'mdi:clock-check-outline',
+        'availability':    avail_base(f"{topic_prefix}/availability"),
+        'device':          device_block(topic_prefix, device_name, model),
+        'entity_category': 'config',
+    }
+    topic = (f"{ha_discovery_prefix}/button/"
+             f"{topic_prefix}/sync_clock/config")
+    return [(topic, encode(cfg))]

--- a/mqtt_demo/samples/oven.py
+++ b/mqtt_demo/samples/oven.py
@@ -25,6 +25,7 @@ import time
 
 from ..descriptor import (
     ApplianceDescriptor,
+    ClockSync,
     avail_base,
     avail_with_cycle,
     avail_with_remote_and_cycle,
@@ -845,6 +846,20 @@ OVEN_POLL_TIERS = [
 ]
 
 
+# The oven's own wall clock. `x.com.samsung.da.currentTime` on
+# `/configuration/vs/0` came from LocalThings #404 / #428, verified
+# there on a TP1X range; both the periodic write and the button answer
+# 2.04 on this oven too (TP1X_DA-KS-OVEN-0107X, 2026-09-08). The field is
+# write-only: a GET of the resource still comes back empty, so the
+# front panel is the only read-back. Panel set to 19:47 by hand, synced
+# at 17:48, panel followed -- the write lands, it is not just accepted.
+OVEN_CLOCK_SYNC = ClockSync(
+    path_segs=['configuration', 'vs', '0'],
+    field='x.com.samsung.da.currentTime',
+    requires_href='/configuration/vs/0',
+)
+
+
 def _is_active(links: dict) -> bool:
     rep = links.get('/operational/state/vs/0') or {}
     sam_state = rep.get('x.com.samsung.da.state')
@@ -867,4 +882,5 @@ OVEN = ApplianceDescriptor(
     log_state_change=log_state_change,
     poll_tiers=OVEN_POLL_TIERS,
     is_active=_is_active,
+    clock_sync=OVEN_CLOCK_SYNC,
 )

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -1,0 +1,218 @@
+"""Appliance clock sync: the write itself, and the two ways it must not fire.
+
+An appliance kept off the internet cannot correct its own clock, so the
+bridge writes the host's to `/configuration/vs/0`. Two properties carry
+the safety of that feature. The field is write-only, so nothing about
+the write may reach the state cache -- a cached copy would be state the
+bridge invented and the appliance can never confirm. And a timestamp far
+outside the appliance's certificate validity window can break its
+certificate verification, so a host whose own clock is wrong has to skip
+the write rather than push its wrong answer onto the hardware.
+"""
+import threading
+import time
+import types
+from datetime import datetime
+
+import cbor2
+import pytest
+
+from mqtt_demo.bridge import CMD_SYNC_CLOCK, PushBridge
+from mqtt_demo.clock_sync import (
+    INITIAL_DELAY_S,
+    PLAUSIBLE_FROM,
+    ClockSyncTask,
+)
+from mqtt_demo.config import SharedConfig
+from mqtt_demo.descriptor import ClockSync
+from mqtt_demo.samples.oven import OVEN
+
+HREF = '/configuration/vs/0'
+FIELD = 'x.com.samsung.da.currentTime'
+SPEC = ClockSync(path_segs=['configuration', 'vs', '0'], field=FIELD,
+                 requires_href=HREF)
+
+
+class _Session:
+    """Records posts; answers with whatever code the test asked for."""
+
+    def __init__(self, code=0x44):
+        self.code = code
+        self.posts = []
+
+    def post(self, path_segs, payload, timeout=None):
+        self.posts.append((list(path_segs), cbor2.loads(payload)))
+        return self.code, b''
+
+
+def _task(session, now, **kwargs):
+    return ClockSyncTask(session, SPEC.path_segs, SPEC.field,
+                         interval_s=86400.0, now_fn=lambda: now, **kwargs)
+
+
+# --- the write ------------------------------------------------------
+
+def test_write_carries_local_wall_clock_in_the_appliance_format():
+    session = _Session()
+    task = _task(session, datetime(2026, 9, 8, 14, 30, 5))
+
+    assert task.sync_now() is True
+    assert session.posts == [
+        (['configuration', 'vs', '0'], {FIELD: '2026-09-08T14:30:05'})]
+
+
+def test_a_rejected_write_is_reported_and_leaves_the_schedule_alone():
+    # The write is unverified on the oven this repo targets. A device
+    # that answers 4.05 must not look like a successful sync, or the
+    # next one would be deferred a full interval on nothing.
+    session = _Session(code=0x85)
+    task = _task(session, datetime(2026, 9, 8, 14, 30, 5))
+
+    assert task.sync_now() is False
+    assert task.sync_count == 0
+    assert task.last_sync_ts is None
+
+
+# --- host-clock gate ------------------------------------------------
+
+@pytest.mark.parametrize('now', [
+    datetime(1970, 1, 1, 0, 0, 0),      # container up before NTP lands
+    datetime(2025, 12, 31, 23, 59, 59),  # just under the floor
+    datetime(2046, 1, 1, 0, 0, 0),      # ceiling is exclusive
+])
+def test_an_implausible_host_clock_writes_nothing(now):
+    session = _Session()
+    task = _task(session, now)
+
+    assert task.sync_now() is False
+    assert session.posts == []
+
+
+def test_the_floor_itself_is_plausible():
+    session = _Session()
+    task = _task(session, PLAUSIBLE_FROM)
+
+    assert task.sync_now() is True
+
+
+# --- schedule across reconnects -------------------------------------
+
+def test_first_session_waits_only_the_initial_delay():
+    task = _task(_Session(), datetime(2026, 9, 8, 14, 0, 0))
+
+    assert task._initial_delay() == INITIAL_DELAY_S
+
+
+def test_a_reconnect_does_not_restart_the_interval():
+    # The task is session-scoped but the schedule is not: a bridge
+    # reconnecting every few minutes would otherwise write the clock on
+    # every reconnect instead of once a day.
+    task = _task(_Session(), datetime(2026, 9, 8, 14, 0, 0),
+                 last_sync_ts=time.time() - 3600.0)
+
+    assert task._initial_delay() == pytest.approx(86400.0 - 3600.0, abs=5.0)
+
+
+def test_an_overdue_sync_still_honours_the_initial_delay():
+    # Due long ago, but the connect burst (seed + discovery) comes first.
+    task = _task(_Session(), datetime(2026, 9, 8, 14, 0, 0),
+                 last_sync_ts=time.time() - 90_000.0)
+
+    assert task._initial_delay() == INITIAL_DELAY_S
+
+
+def test_run_forever_exits_on_stop_without_writing():
+    session = _Session()
+    task = _task(session, datetime(2026, 9, 8, 14, 0, 0))
+    stop = threading.Event()
+    stop.set()
+
+    task.run_forever(stop)
+
+    assert session.posts == []
+
+
+# --- bridge wiring ---------------------------------------------------
+
+def _bridge(*, descriptor_spec=SPEC, interval_h=24.0, links=(HREF,)):
+    bridge = object.__new__(PushBridge)
+    bridge.descriptor = types.SimpleNamespace(clock_sync=descriptor_spec)
+    bridge.shared = types.SimpleNamespace(CLOCK_SYNC_INTERVAL_H=interval_h)
+    bridge.clock_sync_enabled = (descriptor_spec is not None
+                                 and interval_h > 0)
+    bridge._last_clock_sync_ts = None
+    bridge.log = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+    )
+    bridge.cache = types.SimpleNamespace(links={href: {} for href in links})
+    return bridge
+
+
+def test_the_task_is_skipped_when_the_device_lacks_the_resource():
+    bridge = _bridge(links=('/mode/vs/0',))
+
+    assert bridge._build_clock_sync(_Session()) is None
+
+
+def test_the_task_is_built_when_the_resource_is_present():
+    bridge = _bridge()
+
+    task = bridge._build_clock_sync(_Session())
+
+    assert task is not None
+    assert task.href == HREF
+    assert task.interval_s == 86400.0
+
+
+def test_a_zero_interval_disables_the_task():
+    bridge = _bridge(interval_h=0.0)
+
+    assert bridge.clock_sync_enabled is False
+    assert bridge._build_clock_sync(_Session()) is None
+
+
+def test_the_button_write_never_enters_the_cache():
+    # handle_command merges a successful write into the cache
+    # optimistically. The clock field is write-only, so the button is
+    # handled off that path -- this test fails the moment it is folded
+    # back into the descriptor command handlers.
+    bridge = _bridge()
+    session = _Session()
+    bridge.clock_sync = bridge._build_clock_sync(session)
+    bridge.cmd_topic_prefix = 'samsung_oven/cmd/'
+    bridge.cmd_handlers = {}
+    applied = []
+    bridge.cache.apply_optimistic = lambda *a: applied.append(a)
+
+    bridge.handle_command(f'samsung_oven/{CMD_SYNC_CLOCK}', 'Sync')
+
+    assert len(session.posts) == 1
+    assert applied == []
+
+
+def test_the_button_is_ignored_while_no_session_is_up():
+    bridge = _bridge()
+    bridge.clock_sync = None
+    bridge.cmd_topic_prefix = 'samsung_oven/cmd/'
+    bridge.cmd_handlers = {}
+
+    bridge.handle_command(f'samsung_oven/{CMD_SYNC_CLOCK}', 'Sync')
+
+
+# --- config + descriptor --------------------------------------------
+
+def test_the_interval_defaults_to_a_day(monkeypatch):
+    monkeypatch.delenv('CLOCK_SYNC_INTERVAL_H', raising=False)
+
+    assert SharedConfig.from_env().CLOCK_SYNC_INTERVAL_H == 24.0
+
+
+def test_the_interval_is_env_tunable(monkeypatch):
+    monkeypatch.setenv('CLOCK_SYNC_INTERVAL_H', '6')
+
+    assert SharedConfig.from_env().CLOCK_SYNC_INTERVAL_H == 6.0
+
+
+def test_the_oven_declares_the_clock_resource():
+    assert OVEN.clock_sync == SPEC

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -53,12 +53,20 @@ def _task(session, now, **kwargs):
 # --- the write ------------------------------------------------------
 
 def test_write_carries_local_wall_clock_in_the_appliance_format():
+    # Asserted by parsing rather than against a literal timestamp, which
+    # tools/check_share_safety.py rejects in public files.
+    now = datetime(2026, 9, 8, 14, 30, 5)
     session = _Session()
-    task = _task(session, datetime(2026, 9, 8, 14, 30, 5))
+    task = _task(session, now)
 
     assert task.sync_now() is True
-    assert session.posts == [
-        (['configuration', 'vs', '0'], {FIELD: '2026-09-08T14:30:05'})]
+    [(path_segs, body)] = session.posts
+    assert path_segs == ['configuration', 'vs', '0']
+    written = body[FIELD]
+    assert datetime.strptime(written, '%Y-%m-%dT%H:%M:%S') == now
+    # Second precision, a literal T, and no offset or trailing Z: the
+    # appliance takes a bare local wall clock.
+    assert len(written) == 19 and written[10] == 'T'
 
 
 def test_a_rejected_write_is_reported_and_leaves_the_schedule_alone():

--- a/tests/test_worker_cleanup.py
+++ b/tests/test_worker_cleanup.py
@@ -129,6 +129,7 @@ def _bridge():
         observe_paths=(),
         poll_tiers=[],
         is_active=lambda _state: False,
+        clock_sync=None,
     )
     bridge.shared = SimpleNamespace(PING_INTERVAL_S=3600.0)
     bridge.app = SimpleNamespace(klass="test")
@@ -140,6 +141,8 @@ def _bridge():
     bridge.scheduler = None
     bridge.keepalive = None
     bridge.observe_refresh = None
+    bridge.clock_sync = None
+    bridge.clock_sync_enabled = False
     bridge._seed_from_device0 = lambda _session: None
     bridge._retag_logger_with_serial = lambda: None
     bridge.maybe_publish_state = lambda **kwargs: None


### PR DESCRIPTION
Closes #79.

An appliance kept off the internet has no way to correct its own clock, so its display drifts. The demo bridge now writes the host's local wall clock to `/configuration/vs/0` as `x.com.samsung.da.currentTime`, on a timer and on a Home Assistant button.

I closed #79 saying the appliances expose nothing to write. I had searched 86 device-tree dumps for a writable time field; the field is write-only, so no dump could have carried it, and the search could not have found it however long I ran it. LocalThings [#404](https://github.com/mbillow/localthings/issues/404) / [#428](https://github.com/mbillow/localthings/pull/428) had already verified it on a TP1X range.

## Hardware

Reference oven, TP1X_DA-KS-OVEN-0107X, on the Unraid deployment:

```
17:43:39  clock sync (periodic) /configuration/vs/0 = 2026-09-08T17:43:38 -> 2.04
17:48:09  clock sync (mqtt)     /configuration/vs/0 = 2026-09-08T17:48:09 -> 2.04
```

I set the oven's panel clock to 19:47 by hand and synced at 17:48; the panel moved to 17:48. A GET of the resource still returns nothing, so the panel is the only read-back there is.

## Why the demo and not the library

`post()` already sends this, so the library needs no new surface. Home Assistant users get the feature from LocalThings' own Sync clock button, shipped in #428. What was missing here was an example of running it on a schedule, which is what this adds.

## Shape

`ClockSyncTask` is a session worker like `KeepaliveTask` and `ObserveRefreshTask`, but its schedule outlives the session: `last_sync_ts` travels through the bridge, so a connection that flaps still writes on the configured interval. A descriptor declares where its class takes the write through a `ClockSync` spec, and the task is only built once the seed shows the device carries the resource.

Two things the write must not do:

- **Reach the state cache.** `handle_command` merges a successful write optimistically, and a write-only field has nothing to merge into, so the button is handled off the descriptor command path. A test fails if it is ever folded back in.
- **Carry a wrong host clock.** A timestamp outside the device certificate's validity window can break certificate verification and leave the appliance unresponsive, which both LocalThings and the [SmartThings forum thread](https://community.smartthings.com/t/samsung-oven-range-and-cooktop-sync-time-api/251391) the field came from warn about. A host reading outside `PLAUSIBLE_FROM`/`PLAUSIBLE_UNTIL` skips the write, so a container that boots before NTP lands writes nothing.

Oven-only for now. `/configuration/vs/0` is writable on the dryer too, but the laundry dumps carry `TimeSync_NotSupported` and I have not tried the clock field there.

`CLOCK_SYNC_INTERVAL_H` defaults to 24 hours; `0` turns off both the timer and the button.

## Tests

`tests/test_clock_sync.py`, 18 cases: wire format, rejection handling, the host-clock gate, the schedule across reconnects, resource-absent and interval-0 gating, and the cache one above. Full suite 757 passed.
