### PR TITLE
Log the zone each clock-sync stamp was written in

### DIFF
--- a/mqtt_demo/.env.example
+++ b/mqtt_demo/.env.example
@@ -77,6 +77,11 @@ CLOCK_SYNC_INTERVAL_H=24
 
 # Container TZ. Also the timezone written to the appliance clock by
 # the sync above, since the appliance takes a local wall-clock string.
+# Leaving it unset is not neutral: the container falls back to UTC, the
+# appliance answers 2.04 to a wall clock that is an hour behind for as
+# long as summer time is in force, and nothing about the write looks
+# wrong. The zone is logged beside each stamp so the panel and the log
+# can be compared.
 TZ=Europe/London
 
 

--- a/mqtt_demo/clock_sync.py
+++ b/mqtt_demo/clock_sync.py
@@ -41,6 +41,20 @@ from smartthings_local.protocol.dtls_session import DtlsCoapSession
 # no offset and no 'Z'.
 TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
+
+def zone_name(now: datetime) -> str:
+    """Return the zone abbreviation the stamp was written in.
+
+    The wire format carries no offset, so the stamp alone cannot show
+    which zone produced it and a container running UTC writes a panel an
+    hour behind during BST while still answering 2.04. Logging the zone
+    beside the stamp is what separates those two cases.
+    """
+    try:
+        return now.astimezone().tzname() or time.tzname[0]
+    except (OverflowError, OSError, ValueError):
+        return time.tzname[0]
+
 # Host-clock sanity gate. A container that came up before its NTP sync
 # lands (or with no RTC at all) reports a date well before this floor;
 # writing that to the appliance is the failure mode the forum thread
@@ -99,10 +113,10 @@ class ClockSyncTask:
         if not (PLAUSIBLE_FROM <= now < PLAUSIBLE_UNTIL):
             if self.log:
                 self.log.warning(
-                    "clock sync (%s) skipped: host clock reads %s, outside "
-                    "the plausible window -- writing it could break the "
-                    "appliance's certificate verification",
-                    reason, now.strftime(TIME_FORMAT))
+                    "clock sync (%s) skipped: host clock reads %s %s, "
+                    "outside the plausible window -- writing it could break "
+                    "the appliance's certificate verification",
+                    reason, now.strftime(TIME_FORMAT), zone_name(now))
             return False
 
         stamp = now.strftime(TIME_FORMAT)
@@ -127,8 +141,8 @@ class ClockSyncTask:
         # bridge rather than state the device reported.
         if self.log:
             log = self.log.info if ok else self.log.warning
-            log("clock sync (%s) %s = %s -> %s",
-                reason, self.href, stamp, fmt_code(code))
+            log("clock sync (%s) %s = %s %s -> %s",
+                reason, self.href, stamp, zone_name(now), fmt_code(code))
         return ok
 
     def _initial_delay(self) -> float:

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -22,6 +22,7 @@ from mqtt_demo.clock_sync import (
     INITIAL_DELAY_S,
     PLAUSIBLE_FROM,
     ClockSyncTask,
+    zone_name,
 )
 from mqtt_demo.config import SharedConfig
 from mqtt_demo.descriptor import ClockSync
@@ -79,6 +80,74 @@ def test_a_rejected_write_is_reported_and_leaves_the_schedule_alone():
     assert task.sync_now() is False
     assert task.sync_count == 0
     assert task.last_sync_ts is None
+
+
+# --- the zone the stamp was written in -------------------------------
+
+class _Log:
+    """Captures each formatted line, whichever level it came in at."""
+
+    def __init__(self):
+        self.lines = []
+
+    def _record(self, msg, *args):
+        self.lines.append(msg % args)
+
+    info = warning = _record
+
+
+@pytest.fixture
+def host_zone(monkeypatch):
+    """Put the host in a named zone for the duration of one test."""
+    def _set(name):
+        monkeypatch.setenv('TZ', name)
+        time.tzset()
+    yield _set
+    monkeypatch.undo()
+    time.tzset()
+
+
+@pytest.mark.parametrize('zone, expected', [
+    ('UTC', 'UTC'),
+    ('Europe/London', 'BST'),
+])
+def test_the_log_line_names_the_zone_the_stamp_came_from(
+        host_zone, zone, expected):
+    # The wire format carries no offset, so a container left on UTC
+    # writes a panel an hour behind during BST and still answers 2.04.
+    # The stamp alone cannot tell those apart; the zone beside it can.
+    host_zone(zone)
+    session = _Session()
+    log = _Log()
+    task = _task(session, datetime(2026, 9, 8, 14, 30, 5), logger=log)
+
+    assert task.sync_now() is True
+    assert len(log.lines) == 1
+    assert f'14:30:05 {expected} ->' in log.lines[0]
+
+
+def test_a_skipped_write_names_the_zone_too(host_zone):
+    # Same reasoning on the gate: a host reading outside the window is
+    # worth knowing the zone of, since a zone fault is one way to get
+    # there.
+    host_zone('Europe/London')
+    session = _Session()
+    log = _Log()
+    task = _task(session, datetime(2000, 1, 1, 0, 0, 0), logger=log)
+
+    assert task.sync_now() is False
+    assert session.posts == []
+    assert 'GMT' in log.lines[0]
+
+
+def test_the_zone_falls_back_rather_than_raising():
+    # zone_name sits on a log path. A platform that cannot resolve the
+    # local zone must not take the sync down with it.
+    class _NoZone:
+        def astimezone(self):
+            raise OSError('no local zone')
+
+    assert zone_name(_NoZone()) == time.tzname[0]
 
 
 # --- host-clock gate ------------------------------------------------


### PR DESCRIPTION
`ClockSyncTask` writes a wall clock with no offset, because that is what the appliance takes. The stamp alone therefore cannot show which zone produced it, and a container with no `TZ` set falls back to UTC and writes a panel an hour behind for as long as summer time is in force. The appliance answers `2.04` either way, and the plausibility gate cannot catch it because a UTC timestamp is perfectly plausible.

My own bridge had been doing this since the feature shipped. The oven's panel was an hour behind, and separating "the clock sync wrote the wrong time" from "the appliance is drifting on its own" took a `docker exec` into the container, because the log line showed only the stamp:

```
clock sync (periodic) /configuration/vs/0 = 2026-09-08T18:24:06 -> 2.04
```

It now carries the zone, which makes the same line answer the question on its own:

```
clock sync (periodic) /configuration/vs/0 = 2026-09-08T20:04:41 BST -> 2.04
```

`zone_name` resolves the zone of the stamp rather than the host's current one, so an injected `now_fn` stays consistent with what gets logged, and it falls back to `time.tzname` where a local zone cannot be resolved: a log line has no business taking the sync down with it. The skip warning on the plausibility gate gets the same treatment, since a zone fault is one way to land outside the window.

`.env.example` carried `TZ` already and said what it was for. It now says what leaving it unset costs.

No library change, and no change to what goes on the wire. Demo bridge and its tests only.

**Tested:** deployed to my Unraid bridge and recreated the container, which is what an `env_file` change needs. Both appliances reconnected clean, and the first sync of the session wrote BST to the oven and moved the panel. 761 tests pass, `check_share_safety.py --changed-since main` clean.

https://claude.ai/code/session_01UJBUFo8zZWrebGqf6gUzcL
