### PR TITLE
Namespace the appdata path, and pin the unusable-port case

### DIFF
--- a/mqtt_demo/.env.example
+++ b/mqtt_demo/.env.example
@@ -85,7 +85,19 @@ CLOCK_SYNC_INTERVAL_H=24
 TZ=Europe/London
 
 
+# Verbose per-resource logging. 1 logs every representation the
+# appliance returns and each state publish, which is what you want when
+# working out why a sensor is not moving, and far too much otherwise.
+# Any other value (or unset) leaves it off.
+DEBUG_BRIDGE=0
+
+
 # --- Deploy (deploy.sh — tar + ssh docker compose) ---
 SSH_HOST=user@your-server
 REMOTE_DIR=/mnt/user/compose/smartthings-local
-APPDATA_DIR=/mnt/user/appdata/smartthings-local
+# Prefixed on purpose. docker-compose.yml interpolates this into the
+# /config bind mount, and Compose gives a shell-exported variable
+# precedence over this file. A bare APPDATA_DIR sourced from a sibling
+# project's .env would therefore mount that project's directory here,
+# silently and only until the container is recreated.
+SMARTTHINGS_LOCAL_APPDATA_DIR=/mnt/user/appdata/smartthings-local

--- a/mqtt_demo/deploy.sh
+++ b/mqtt_demo/deploy.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 # Sync source + .env to the remote and rebuild the container.
 #
-# Two host paths are used:
-#   REMOTE_DIR  — compose project (source code, .env, docker-compose.yml)
-#                 Convention: /mnt/user/compose/samsung-bridge/
-#   APPDATA_DIR — bind-mount source for /config inside the container
-#                 (client cert + key live here).
-#                 Convention: /mnt/user/appdata/samsung-bridge/
+# Two host paths are used, both read from .env:
+#   REMOTE_DIR — compose project (source code, .env, docker-compose.yml)
+#                Convention: /mnt/user/compose/smartthings-local/
+#   SMARTTHINGS_LOCAL_APPDATA_DIR — bind-mount source for /config inside
+#                the container (client cert + key live here).
+#                Convention: /mnt/user/appdata/smartthings-local/
+#                Prefixed because docker-compose.yml interpolates it and
+#                Compose prefers a shell-exported variable over .env.
 #
-# The remote must already have the certs in $APPDATA_DIR. Run once
-# before the first deploy:
+# The remote must already have the certs there. Run once before the
+# first deploy:
 #
-#   source .env
-#   ssh "$SSH_HOST" mkdir -p "$APPDATA_DIR"
+#   set -a; source .env; set +a
+#   ssh "$SSH_HOST" mkdir -p "$SMARTTHINGS_LOCAL_APPDATA_DIR"
 #   scp certs/client_fullchain.pem certs/client.key \
-#       "$SSH_HOST:$APPDATA_DIR/"
+#       "$SSH_HOST:$SMARTTHINGS_LOCAL_APPDATA_DIR/"
 #
 # Subsequent deploys (this script) ship source code + .env only; the
-# certs in $APPDATA_DIR are preserved.
+# certs already there are preserved.
 set -e
 
 # This script lives in mqtt_demo/ but the build context is the repo
@@ -40,11 +42,11 @@ get_env() {
 }
 SSH_HOST=$(get_env SSH_HOST)
 REMOTE_DIR=$(get_env REMOTE_DIR)
-APPDATA_DIR=$(get_env APPDATA_DIR)
+APPDATA_DIR=$(get_env SMARTTHINGS_LOCAL_APPDATA_DIR)
 
 : "${SSH_HOST:?SSH_HOST not set in .env}"
 : "${REMOTE_DIR:?REMOTE_DIR not set in .env}"
-: "${APPDATA_DIR:?APPDATA_DIR not set in .env}"
+: "${APPDATA_DIR:?SMARTTHINGS_LOCAL_APPDATA_DIR not set in .env}"
 
 echo "Deploying to ${SSH_HOST}:${REMOTE_DIR}…"
 ssh "${SSH_HOST}" mkdir -p "${REMOTE_DIR}" "${APPDATA_DIR}"

--- a/mqtt_demo/docker-compose.yml
+++ b/mqtt_demo/docker-compose.yml
@@ -10,10 +10,15 @@ services:
     # broker on 1883). No ports to expose.
 
     volumes:
-      # Holds the client cert + key. APPDATA_DIR comes from .env;
-      # on Unraid this is typically /mnt/user/appdata/smartthings-local/.
-      # Bare-metal dev falls back to ./certs alongside this compose file.
-      - ${APPDATA_DIR:-./certs}:/config:ro
+      # Holds the client cert + key. SMARTTHINGS_LOCAL_APPDATA_DIR comes
+      # from .env; on Unraid this is typically
+      # /mnt/user/appdata/smartthings-local/. Bare-metal dev falls back
+      # to ./certs alongside this compose file. The name is prefixed
+      # because Compose prefers a shell-exported variable over .env, so a
+      # bare APPDATA_DIR left in the shell by a sibling project would
+      # mount that project's directory here until the container is
+      # recreated.
+      - ${SMARTTHINGS_LOCAL_APPDATA_DIR:-./certs}:/config:ro
 
     # All runtime config is in .env. env_file passes every variable
     # straight into the container, so adding a new appliance is a

--- a/tests/test_ocf_discovery.py
+++ b/tests/test_ocf_discovery.py
@@ -157,6 +157,35 @@ def test_primary_distinguishes_absence_from_untrusted_secure_eps():
         ) == (discovery._PORTS_UNTRUSTED, ())
 
 
+@pytest.mark.parametrize('port', (0, -1, 65536, True, 1.0, '61002', None))
+def test_an_unusable_policy_port_reads_as_absence_and_is_never_dialled(port):
+    # Zero is the case the hardware actually produces: RT-OCF binds the
+    # DTLS socket with port 0 and learns the assignment through
+    # getsockname, so a directory serialised before that bind advertises
+    # `sec: true, port: 0`. A live plaintext read on the reference dryer
+    # here has returned exactly that while a later read of the same
+    # device gave a real port. Treating it as a port would send the
+    # handshake at port 0; absence is what lets the caller see
+    # `no_secure_ports` and retry later. `True` is in the list because
+    # bool is a subclass of int and would otherwise pass for port 1.
+    payload = _payload(_doxm_link(port))
+
+    for extractor in (discovery._primary_secure_ports_from_payload,
+                      discovery._fallback_secure_ports_from_payload):
+        assert extractor(payload, socket.AF_INET, _ipv4_key()) == (
+            discovery._PORTS_ABSENT, ())
+
+
+def test_a_usable_port_alongside_an_unusable_one_is_still_found():
+    # The reduced directory carries several sec-flagged links. One
+    # unusable port must not discard the rest of the response.
+    payload = _payload(_doxm_link(0), _doxm_link(61002))
+
+    assert discovery._fallback_secure_ports_from_payload(
+        payload, socket.AF_INET, _ipv4_key()) == (
+            discovery._PORTS_FOUND, (61002,))
+
+
 def test_ipv6_eps_binding_inherits_or_exactly_matches_response_scope():
     source_key = (
         socket.inet_pton(socket.AF_INET6, '2001:db8::20'),


### PR DESCRIPTION
Three things that only show up as a failure once it is too late to see them.

**`docker-compose.yml` interpolated a bare `APPDATA_DIR` into the `/config` bind mount.** Compose gives a shell-exported variable precedence over the project's `.env`, so a `docker compose up` run by hand from a shell that had sourced a sibling project's `.env` would mount that project's directory here. The wrong path then freezes into the container until it is recreated, and nothing logs it. `deploy.sh` is immune, since ssh does not forward the environment, so this could only ever bite an interactive run.

The variable is `SMARTTHINGS_LOCAL_APPDATA_DIR` now, renamed in `.env.example`, `docker-compose.yml` and `deploy.sh` together so the `:?` guard fails loudly rather than falling through to the `./certs` default. `deploy.sh` keeps a short local name internally; nothing exports it, so Compose never sees it.

`DEBUG_BRIDGE` was read by `bridge.py` and documented nowhere. The only way to find it was to grep the source. `.env.example` describes it now.

**`tests/test_ocf_discovery.py` had no case for a policy port the library cannot use.** Zero is the one the hardware produces: RT-OCF binds the DTLS socket with port `0` and learns the assignment through `getsockname`, so a directory serialised before that bind advertises `sec: true, port: 0`. A plaintext read on my reference dryer has returned exactly that, while a later read of the same device gave a real port. Absence is the right answer, because it surfaces as `no_secure_ports` and leaves the caller free to retry rather than sending a handshake at port 0. A bool needs rejecting in the same breath, or `True` passes for port 1. A second case covers one unusable port alongside a usable one, so a single bad link cannot discard the rest of a reduced directory.

While in the `deploy.sh` header: two stale convention paths, and a bootstrap snippet whose `source .env` no longer resolved the key it went on to use.

**Tested:** 769 tests pass, `check_share_safety.py --changed-since main` clean. Deployed to my Unraid bridge and recreated the container: `/config` resolves to `/mnt/user/appdata/smartthings-local` with both certs visible, no `./certs` fallback directory got created, and both appliances reconnected and seeded clean.

https://claude.ai/code/session_01UJBUFo8zZWrebGqf6gUzcL
