### PR TITLE
Diagnose a PSK carrier through the same probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ and covered by the downstream compatibility contract:
 | `smartthings_local.errors` | Classified, redacted library failures |
 | `smartthings_local.protocol.auth` | Certificate, server-certificate, and PSK providers and Samsung server profiles |
 | `smartthings_local.protocol.dtls_session` | Sustained CoAP-DTLS sessions and connect cancellation |
-| `smartthings_local.protocol.dtls_probe` | Stateless DTLS liveness results and single/multi-port probes |
+| `smartthings_local.protocol.dtls_probe` | Stateless DTLS liveness results, single/multi-port probes, and the opt-in provider-aware handshake diagnostic |
 | `smartthings_local.protocol.endpoint` | Resolved IPv4/IPv6 UDP endpoints and connected/host-filtered socket setup |
 | `smartthings_local.protocol.ocf_discovery` | Bounded plaintext OCF reads and advertised secure-port discovery |
 | `smartthings_local.protocol.ocf_multicast` | Known-host OCF responder-port discovery |
@@ -685,6 +685,23 @@ python -m smartthings_local.protocol.dtls_probe "$APPLIANCE_IP" 5684 49153 49154
 ```
 
 `live` means a DTLS server answered its first flight; `dead` means silent or not DTLS. Once you have the client cert (Part 2), add the explicit `--diagnostic` flag to run the stateful diagnostic drive, which reports `completed` (cert accepted) or `rejected` with the server's fatal alert. Diagnostic mode can allocate appliance-side DTLS state and is never used by discovery or reconnect. An `unsupported_certificate` / `unknown_ca` alert means the endpoint is reachable but this certificate profile was rejected. It is not a reason to disable verification or keep retrying. The same bounded stateless API gates the bridge's reconnect loop and, when `OCF_PORT` is unset, probes both standard 5684 and ports 49152–49160.
+
+A device that rejects the certificate profile may still run a PSK endpoint, and `diagnose_dtls_handshake` takes any authentication provider through `auth=` so that carrier can be characterised the same way:
+
+```python
+from smartthings_local.protocol.auth import PskAuth
+from smartthings_local.protocol.dtls_probe import diagnose_dtls_handshake
+
+result = diagnose_dtls_handshake(
+    appliance_host,
+    secure_port,
+    auth=PskAuth(identity=psk_identity, key=psk_key),
+)
+```
+
+`auth=` is mutually exclusive with `cert_pem`/`key_pem`/`cert_path`/`key_path`. A `rejected` outcome carrying `unknown_psk_identity` means the endpoint negotiated ECDHE-PSK and then refused the credential, which distinguishes a PSK device from one with no local DTLS at all. The CLI exposes the same thing as `--diagnostic --psk-identity HEX --psk-key HEX`, and since a command line is readable by every process on the host, pass a throwaway value there rather than a real credential.
+
+A diagnostic never enforces trust, whichever credential it is given. A provider's own verification, including a `SamsungServerProfile`'s pinned server identity, is deliberately not honoured: the result has to report what the appliance did, so an untrusted chain is classified rather than rejected locally. Use `DtlsCoapSession` when the trust decision is the point.
 
 Consumers can discover ports outside that fallback range through the public,
 read-only OCF resource directory before probing them:

--- a/smartthings_local/protocol/dtls_probe.py
+++ b/smartthings_local/protocol/dtls_probe.py
@@ -56,6 +56,9 @@ _HS_NAMES = {
     1: 'ClientHello',
     2: 'ServerHello',
     3: 'HelloVerifyRequest',
+    # RFC 5077. Sent in the clear ahead of the server's ChangeCipherSpec, so
+    # a completed handshake legitimately reports it.
+    4: 'NewSessionTicket',
     11: 'Certificate',
     12: 'ServerKeyExchange',
     13: 'CertificateRequest',
@@ -663,13 +666,22 @@ def diagnose_dtls_handshake(
     started = time.monotonic()
     deadline = started + timeout
     seen = set()
+    encrypted = False
 
     def record_datagram(datagram):
+        nonlocal encrypted
         if result.rtt_s is None:
             result.rtt_s = time.monotonic() - started
         result.datagrams.append(datagram)
         for content_type, detail in classify_datagram(datagram):
-            if content_type == _CT_HANDSHAKE:
+            if content_type == _CT_CHANGE_CIPHER_SPEC:
+                # Handshake records after this one are encrypted, so their
+                # first byte is ciphertext and not a message type. Reading it
+                # as one invents a message: roughly one ciphertext byte in
+                # 256 collides with a name in _HS_NAMES, which is frequent
+                # enough to have produced a phantom 'Finished' in testing.
+                encrypted = True
+            elif content_type == _CT_HANDSHAKE and not encrypted:
                 if detail not in seen:
                     seen.add(detail)
                     result.handshake_msgs.append(detail)

--- a/smartthings_local/protocol/dtls_probe.py
+++ b/smartthings_local/protocol/dtls_probe.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from OpenSSL import SSL
 
 from ..errors import ProbeError
-from .auth import _DTLS_CIPHERS, _OCF_ROOT_CA, _load_pem_chain
+from .auth import PskAuth, _DTLS_CIPHERS, _OCF_ROOT_CA, _load_pem_chain
 from .coap import split_dtls
 from .dtls_handshake import _drive_dtls_handshake
 from .endpoint import open_host_filtered_udp_socket
@@ -89,6 +89,9 @@ _ALERT_NAMES = {
     86: 'inappropriate_fallback',
     90: 'user_canceled',
     112: 'unrecognized_name',
+    # RFC 4279 §2. The alert a PSK carrier fails with, so an `auth=PskAuth`
+    # diagnosis names it instead of reporting a bare number.
+    115: 'unknown_psk_identity',
     116: 'certificate_required',
 }
 
@@ -559,8 +562,53 @@ def probe(host, port, *, cert_pem=None, key_pem=None,
     return result
 
 
+def _accept_any_peer_chain(*_args):
+    """Accept any chain a server sends.
+
+    A probe classifies what arrives; it does not gate on our trust decision.
+    """
+    return True
+
+
+def _validate_diagnostic_auth(auth, cert_pem, key_pem, cert_path, key_path):
+    if auth is None:
+        return
+    if (cert_pem is not None or key_pem is not None
+            or cert_path is not None or key_path is not None):
+        raise ValueError(
+            'pass either auth or cert_pem/key_pem/cert_path/key_path, '
+            'not both')
+    if not callable(getattr(auth, 'configure_context', None)):
+        raise TypeError('auth must be an AuthenticationProvider')
+
+
+def _diagnostic_context(*, auth, cert_pem, key_pem, cert_path, key_path):
+    """Build one diagnostic context that never gates on our trust decision."""
+    ctx = SSL.Context(SSL.DTLS_METHOD)
+    ctx.load_verify_locations(_OCF_ROOT_CA)
+    ctx.set_verify(SSL.VERIFY_PEER, _accept_any_peer_chain)
+    ctx.set_cipher_list(_DTLS_CIPHERS)
+    if auth is not None:
+        auth.configure_context(ctx)
+        # Providers configure a context to *gate* on trust: CertificateAuth
+        # installs OpenSSL's own verdict, and a SamsungServerProfile pins an
+        # identity from inside the verify callback. Either one turns an
+        # appliance's alert into a local verify failure, which is the single
+        # thing a diagnostic must not do, so accept-any is re-asserted last.
+        # A PSK provider's cipher list survives that, because VERIFY_PEER is
+        # never consulted for a ciphersuite carrying no certificate.
+        ctx.set_verify(SSL.VERIFY_PEER, _accept_any_peer_chain)
+    elif cert_pem is not None:
+        _load_pem_chain(ctx, cert_pem, key_pem)
+    elif cert_path is not None:
+        ctx.use_certificate_chain_file(cert_path)
+        ctx.use_privatekey_file(key_path)
+        ctx.check_privatekey()
+    return ctx
+
+
 def diagnose_dtls_handshake(
-        host, port, *, cert_pem=None, key_pem=None,
+        host, port, *, auth=None, cert_pem=None, key_pem=None,
         cert_path=None, key_path=None,
         retries=2, timeout=3.0, mtu=1200,
         family=socket.AF_UNSPEC):
@@ -570,23 +618,32 @@ def diagnose_dtls_handshake(
     into OpenSSL. It can therefore emit a cookie-bearing second ClientHello and
     allocate appliance-side association state. Keep it out of discovery,
     reconnect, and other production liveness paths.
+
+    ``auth`` takes any :mod:`~smartthings_local.protocol.auth` authentication
+    provider, so a PSK carrier can be diagnosed on the same footing as a
+    certificate one. It is mutually exclusive with the
+    ``cert_pem``/``key_pem``/``cert_path``/``key_path`` inputs, which remain
+    supported for certificate credentials.
+
+    A diagnostic never enforces trust, whichever credential reaches it. A
+    provider's own verification, including a ``SamsungServerProfile``'s pinned
+    server identity, is deliberately not honoured here: the result has to
+    report what the appliance did, so an untrusted chain is classified rather
+    than rejected locally. Use :class:`DtlsCoapSession` for a session that
+    does gate on trust.
     """
     _validate_liveness_options(port, retries, timeout, mtu)
     _validate_probe_family(family)
+    _validate_diagnostic_auth(auth, cert_pem, key_pem, cert_path, key_path)
     result = ProbeResult(host, port)
 
-    ctx = SSL.Context(SSL.DTLS_METHOD)
-    ctx.load_verify_locations(_OCF_ROOT_CA)
-    # Accept the chain unconditionally: a probe classifies what the server
-    # sends, it does not gate on our trust decision.
-    ctx.set_verify(SSL.VERIFY_PEER, lambda *a: True)
-    ctx.set_cipher_list(_DTLS_CIPHERS)
-    if cert_pem is not None:
-        _load_pem_chain(ctx, cert_pem, key_pem)
-    elif cert_path is not None:
-        ctx.use_certificate_chain_file(cert_path)
-        ctx.use_privatekey_file(key_path)
-        ctx.check_privatekey()
+    ctx = _diagnostic_context(
+        auth=auth,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        cert_path=cert_path,
+        key_path=key_path,
+    )
 
     conn = SSL.Connection(ctx, None)
     conn.set_connect_state()
@@ -653,10 +710,15 @@ def _main(argv):
 
     if len(argv) < 2:
         print('usage: python -m smartthings_local.protocol.dtls_probe '
-              'HOST PORT [PORT...] [--diagnostic --cert FILE --key FILE]')
+              'HOST PORT [PORT...] [--diagnostic]\n'
+              '         [--cert FILE --key FILE]\n'
+              '         [--psk-identity HEX --psk-key HEX]\n'
+              'A PSK passed here is visible to every process on the host; '
+              'use a throwaway value.')
         return 2
     host = argv[0]
     cert_path = key_path = None
+    psk_identity = psk_key = None
     diagnostic = False
     ports = []
     it = iter(argv[1:])
@@ -665,6 +727,10 @@ def _main(argv):
             cert_path = next(it)
         elif a == '--key':
             key_path = next(it)
+        elif a == '--psk-identity':
+            psk_identity = next(it)
+        elif a == '--psk-key':
+            psk_key = next(it)
         elif a == '--diagnostic':
             diagnostic = True
         elif a == '--stateless':
@@ -682,14 +748,37 @@ def _main(argv):
     if (cert_path is None) != (key_path is None):
         print('--cert and --key must be supplied together')
         return 2
-    if not diagnostic and (cert_path is not None or key_path is not None):
-        print('--cert/--key require the explicit --diagnostic mode')
+    if (psk_identity is None) != (psk_key is None):
+        print('--psk-identity and --psk-key must be supplied together')
+        return 2
+    if cert_path is not None and psk_identity is not None:
+        print('pass either --cert/--key or --psk-identity/--psk-key, '
+              'not both')
+        return 2
+    credential_supplied = cert_path is not None or psk_identity is not None
+    if not diagnostic and credential_supplied:
+        print('a credential requires the explicit --diagnostic mode')
         return 2
 
+    auth = None
+    if psk_identity is not None:
+        try:
+            auth = PskAuth(
+                identity=bytes.fromhex(psk_identity),
+                key=bytes.fromhex(psk_key),
+            )
+        except ValueError as exc:
+            print(f'invalid PSK credential: {exc}')
+            return 2
+
+    credential_kwargs = (
+        {'auth': auth}
+        if auth is not None
+        else {'cert_path': cert_path, 'key_path': key_path}
+    )
     target = diagnose_dtls_handshake if diagnostic else probe
     with cf.ThreadPoolExecutor(max_workers=max(1, len(ports))) as ex:
-        futs = {ex.submit(target, host, p, cert_path=cert_path,
-                          key_path=key_path): p
+        futs = {ex.submit(target, host, p, **credential_kwargs): p
                 for p in ports}
         results = [f.result() for f in cf.as_completed(futs)]
 

--- a/tests/test_dtls_probe.py
+++ b/tests/test_dtls_probe.py
@@ -663,21 +663,18 @@ def test_diagnostic_certificate_provider_matches_inline_pem_credentials(
         result = p.diagnose_dtls_handshake(
             '127.0.0.1', 5684, timeout=2.0, **credentials
         )
-        # Records arriving after ChangeCipherSpec are encrypted, and
-        # classify_datagram reads their first ciphertext byte as a message
-        # type, so `handshake_msgs` ends in nondeterministic `hsNN` entries.
-        # Parity is asserted over the named flight, which is the part that
-        # describes the handshake.
-        named_flight = tuple(
-            name for name in result.handshake_msgs
-            if name in set(p._HS_NAMES.values())
+        outcomes.append(
+            (result.outcome, tuple(result.handshake_msgs), result.alert)
         )
-        outcomes.append((result.outcome, named_flight, result.alert))
 
     assert outcomes[0] == outcomes[1]
     assert outcomes[0][0] == p.COMPLETED
-    assert outcomes[0][1][:4] == (
-        'ServerHello', 'Certificate', 'ServerKeyExchange', 'ServerHelloDone',
+    assert outcomes[0][1] == (
+        'ServerHello',
+        'Certificate',
+        'ServerKeyExchange',
+        'ServerHelloDone',
+        'NewSessionTicket',
     )
 
 
@@ -787,3 +784,23 @@ def test_cli_reports_an_unusable_psk_credential_without_a_traceback(capsys):
 
     assert result == 2
     assert 'invalid PSK credential' in capsys.readouterr().out
+
+
+def test_encrypted_records_do_not_invent_handshake_messages(monkeypatch):
+    # A handshake record after ChangeCipherSpec is encrypted, so its first
+    # byte is ciphertext. Read as a message type it names whatever it
+    # collides with, and roughly one byte in 256 collides with a name in
+    # _HS_NAMES: this fabricated a 'Finished' once in 30 real handshakes
+    # before the suppression went in. 20 is Finished's type value.
+    responses = iter((
+        _hvr(),
+        _rec(p._CT_CHANGE_CIPHER_SPEC, b'\x01')
+        + _rec(p._CT_HANDSHAKE, bytes([20]) + b'ciphertext'),
+    ))
+    fake = _FakeSock(lambda _f: next(responses, None))
+    _patch_sock(monkeypatch, fake)
+
+    result = p.diagnose_dtls_handshake('127.0.0.1', 5684, timeout=0.3)
+
+    assert result.handshake_msgs == ['HelloVerifyRequest']
+    assert 'Finished' not in result.handshake_msgs

--- a/tests/test_dtls_probe.py
+++ b/tests/test_dtls_probe.py
@@ -526,18 +526,19 @@ class _LoopbackDtlsServer:
 
 
 def _server_context(*, cipher, cert_pem=None, key_pem=None, psk=False):
-    from cryptography import x509
-    from cryptography.hazmat.primitives import serialization
-    from OpenSSL import SSL, _util
+    from OpenSSL import SSL, _util, crypto
 
     context = SSL.Context(SSL.DTLS_METHOD)
     context.set_cipher_list(cipher)
     if cert_pem is not None:
+        # pyOpenSSL's own types: the floor binding in CI rejects a
+        # cryptography certificate here, and the library loads chains the
+        # same way.
         context.use_certificate(
-            x509.load_pem_x509_certificate(cert_pem.encode())
+            crypto.load_certificate(crypto.FILETYPE_PEM, cert_pem.encode())
         )
         context.use_privatekey(
-            serialization.load_pem_private_key(key_pem.encode(), None)
+            crypto.load_privatekey(crypto.FILETYPE_PEM, key_pem.encode())
         )
     if psk:
         ffi = _util.ffi
@@ -559,8 +560,16 @@ def _server_context(*, cipher, cert_pem=None, key_pem=None, psk=False):
     return context
 
 
+# RFC 5746 §3.3. Advertised alongside the real suites by some OpenSSL
+# builds, and it names no cipher, so it is dropped before comparing.
+_EMPTY_RENEGOTIATION_INFO_SCSV = 0x00FF
+
+
 def _client_hello_cipher_suites(datagram):
-    """Read the cipher-suite list out of a DTLS ClientHello datagram."""
+    """Read the offered cipher suites out of a DTLS ClientHello datagram.
+
+    Signalling suite values are excluded, leaving only real ciphers.
+    """
     fragment = datagram[13:13 + int.from_bytes(datagram[11:13], 'big')]
     body = fragment[12:]                      # past the handshake header
     offset = 2 + 32                           # client_version + random
@@ -571,7 +580,7 @@ def _client_hello_cipher_suites(datagram):
     return {
         int.from_bytes(suites[i:i + 2], 'big')
         for i in range(0, len(suites), 2)
-    }
+    } - {_EMPTY_RENEGOTIATION_INFO_SCSV}
 
 
 def test_diagnostic_psk_provider_reaches_an_unknown_psk_identity_alert(
@@ -702,8 +711,9 @@ def test_diagnostic_never_gates_on_a_pinned_server_identity(monkeypatch):
             cert_pem,
             key_pem,
             server_profile=SamsungServerProfile(
+                # tools/check_share_safety.py's allowlisted placeholder.
                 expected_certificate_identity=(
-                    '00000000-0000-4000-8000-000000000001'
+                    '11111111-2222-3333-4444-555555555555'
                 ),
             ),
         ),

--- a/tests/test_dtls_probe.py
+++ b/tests/test_dtls_probe.py
@@ -450,3 +450,330 @@ def test_cli_bounds_port_fanout(capsys):
 
     assert result == 2
     assert 'at most 32 PORT values' in capsys.readouterr().out
+
+
+# --- auth= providers, against a real loopback DTLS server ----------------
+#
+# `_FakeSock` fakes only the datagram transport, so an OpenSSL server driven
+# through its responder produces genuine server flights: a real certificate
+# chain to verify, and a real `unknown_psk_identity` alert from OpenSSL's own
+# PSK path. That is what makes these tests evidence about the handshake
+# rather than about a hand-built record.
+
+_ECDHE_ECDSA_AES128_GCM_SHA256 = 0xC02B
+_ECDHE_PSK_AES128_CBC_SHA256 = 0xC037
+
+
+def _synthetic_ec_server_credentials():
+    """An ECDSA self-signed server cert unrelated to Samsung's hierarchy."""
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    now = datetime.now(timezone.utc)
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, 'Synthetic test server')]
+    )
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(1)
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(hours=1))
+        .sign(key, hashes.SHA256())
+    )
+    return (
+        certificate.public_bytes(serialization.Encoding.PEM).decode(),
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode(),
+    )
+
+
+class _LoopbackDtlsServer:
+    """Drive a real OpenSSL DTLS server from `_FakeSock`'s responder."""
+
+    def __init__(self, context):
+        from OpenSSL import SSL
+
+        self._ssl = SSL
+        self._conn = SSL.Connection(context, None)
+        self._conn.set_accept_state()
+        self._consumed = 0
+
+    def __call__(self, fake):
+        for datagram in fake.sends[self._consumed:]:
+            self._conn.bio_write(datagram)
+        self._consumed = len(fake.sends)
+        try:
+            self._conn.do_handshake()
+        except (self._ssl.WantReadError, self._ssl.Error):
+            # A rejection is emitted into the BIO as an alert record, which
+            # is the flight under test; nothing here should raise onward.
+            pass
+        try:
+            return self._conn.bio_read(65536)
+        except self._ssl.WantReadError:
+            return None
+
+
+def _server_context(*, cipher, cert_pem=None, key_pem=None, psk=False):
+    from cryptography import x509
+    from cryptography.hazmat.primitives import serialization
+    from OpenSSL import SSL, _util
+
+    context = SSL.Context(SSL.DTLS_METHOD)
+    context.set_cipher_list(cipher)
+    if cert_pem is not None:
+        context.use_certificate(
+            x509.load_pem_x509_certificate(cert_pem.encode())
+        )
+        context.use_privatekey(
+            serialization.load_pem_private_key(key_pem.encode(), None)
+        )
+    if psk:
+        ffi = _util.ffi
+
+        @ffi.callback(
+            'unsigned int(*)(SSL *, const char *, unsigned char *, '
+            'unsigned int)'
+        )
+        def server_callback(_ssl, _identity, _key_buffer, _max_key_length):
+            # Every identity is unknown, so OpenSSL raises the RFC 4279
+            # unknown_psk_identity(115) alert itself.
+            return 0
+
+        # Retained on the context object: the callback must outlive this call.
+        context._test_psk_callback = server_callback
+        _util.lib.SSL_CTX_set_psk_server_callback(
+            context._context, server_callback
+        )
+    return context
+
+
+def _client_hello_cipher_suites(datagram):
+    """Read the cipher-suite list out of a DTLS ClientHello datagram."""
+    fragment = datagram[13:13 + int.from_bytes(datagram[11:13], 'big')]
+    body = fragment[12:]                      # past the handshake header
+    offset = 2 + 32                           # client_version + random
+    offset += 1 + body[offset]                # session_id
+    offset += 1 + body[offset]                # cookie
+    length = int.from_bytes(body[offset:offset + 2], 'big')
+    suites = body[offset + 2:offset + 2 + length]
+    return {
+        int.from_bytes(suites[i:i + 2], 'big')
+        for i in range(0, len(suites), 2)
+    }
+
+
+def test_diagnostic_psk_provider_reaches_an_unknown_psk_identity_alert(
+        monkeypatch):
+    # The point of auth=: a PSK carrier is diagnosable on the same footing as
+    # a certificate one, and the alert it fails with is named rather than
+    # reported as a bare 115.
+    from smartthings_local.protocol.auth import PskAuth
+
+    server = _LoopbackDtlsServer(
+        _server_context(cipher=b'ECDHE-PSK-AES128-CBC-SHA256:@SECLEVEL=0',
+                        psk=True)
+    )
+    fake = _FakeSock(server)
+    _patch_sock(monkeypatch, fake)
+
+    result = p.diagnose_dtls_handshake(
+        '127.0.0.1',
+        5684,
+        auth=PskAuth(identity=bytes(range(1, 17)), key=b'k' * 16),
+        timeout=2.0,
+    )
+
+    assert result.alert == (2, 'unknown_psk_identity')
+    assert result.outcome == p.REJECTED
+    assert 'ServerHello' in result.handshake_msgs
+
+
+def test_diagnostic_psk_provider_replaces_the_certificate_cipher_list(
+        monkeypatch):
+    # Ordering guarantee: the provider is applied after the probe's own
+    # baseline, so PskAuth's suite replaces ECDHE-ECDSA rather than being
+    # overwritten by it.
+    from smartthings_local.protocol.auth import PskAuth
+
+    fake = _FakeSock(lambda _f: None)
+    _patch_sock(monkeypatch, fake)
+    p.diagnose_dtls_handshake(
+        '127.0.0.1', 5684,
+        auth=PskAuth(identity=bytes(range(1, 17)), key=b'k' * 16),
+        timeout=0.2, retries=0,
+    )
+    psk_suites = _client_hello_cipher_suites(fake.sends[0])
+
+    certificate_fake = _FakeSock(lambda _f: None)
+    _patch_sock(monkeypatch, certificate_fake)
+    p.diagnose_dtls_handshake('127.0.0.1', 5684, timeout=0.2, retries=0)
+    certificate_suites = _client_hello_cipher_suites(
+        certificate_fake.sends[0]
+    )
+
+    assert psk_suites == {_ECDHE_PSK_AES128_CBC_SHA256}
+    assert certificate_suites == {_ECDHE_ECDSA_AES128_GCM_SHA256}
+
+
+def test_diagnostic_certificate_provider_matches_inline_pem_credentials(
+        monkeypatch):
+    # auth=CertificateAuth has to be a pure re-spelling of cert_pem/key_pem,
+    # since an existing caller's behaviour must not shift under the new
+    # parameter.
+    from smartthings_local.protocol.auth import CertificateAuth
+
+    cert_pem, key_pem = _synthetic_ec_server_credentials()
+    outcomes = []
+    for credentials in (
+        {'cert_pem': cert_pem, 'key_pem': key_pem},
+        {'auth': CertificateAuth.from_memory(cert_pem, key_pem)},
+    ):
+        server_cert, server_key = _synthetic_ec_server_credentials()
+        fake = _FakeSock(
+            _LoopbackDtlsServer(
+                _server_context(
+                    cipher=b'ECDHE-ECDSA-AES128-GCM-SHA256:@SECLEVEL=0',
+                    cert_pem=server_cert,
+                    key_pem=server_key,
+                )
+            )
+        )
+        _patch_sock(monkeypatch, fake)
+        result = p.diagnose_dtls_handshake(
+            '127.0.0.1', 5684, timeout=2.0, **credentials
+        )
+        # Records arriving after ChangeCipherSpec are encrypted, and
+        # classify_datagram reads their first ciphertext byte as a message
+        # type, so `handshake_msgs` ends in nondeterministic `hsNN` entries.
+        # Parity is asserted over the named flight, which is the part that
+        # describes the handshake.
+        named_flight = tuple(
+            name for name in result.handshake_msgs
+            if name in set(p._HS_NAMES.values())
+        )
+        outcomes.append((result.outcome, named_flight, result.alert))
+
+    assert outcomes[0] == outcomes[1]
+    assert outcomes[0][0] == p.COMPLETED
+    assert outcomes[0][1][:4] == (
+        'ServerHello', 'Certificate', 'ServerKeyExchange', 'ServerHelloDone',
+    )
+
+
+def test_diagnostic_never_gates_on_a_pinned_server_identity(monkeypatch):
+    # A SamsungServerProfile pins an identity from inside the verify
+    # callback, which would turn this synthetic server's chain into a local
+    # verify failure. A diagnostic must report what the appliance did, so the
+    # probe re-asserts accept-any last and the handshake still completes.
+    from smartthings_local.protocol.auth import (
+        CertificateAuth,
+        SamsungServerProfile,
+    )
+
+    cert_pem, key_pem = _synthetic_ec_server_credentials()
+    server_cert, server_key = _synthetic_ec_server_credentials()
+    fake = _FakeSock(
+        _LoopbackDtlsServer(
+            _server_context(
+                cipher=b'ECDHE-ECDSA-AES128-GCM-SHA256:@SECLEVEL=0',
+                cert_pem=server_cert,
+                key_pem=server_key,
+            )
+        )
+    )
+    _patch_sock(monkeypatch, fake)
+
+    result = p.diagnose_dtls_handshake(
+        '127.0.0.1',
+        5684,
+        auth=CertificateAuth.from_memory(
+            cert_pem,
+            key_pem,
+            server_profile=SamsungServerProfile(
+                expected_certificate_identity=(
+                    '00000000-0000-4000-8000-000000000001'
+                ),
+            ),
+        ),
+        timeout=2.0,
+    )
+
+    assert result.outcome == p.COMPLETED
+    assert result.error is None
+
+
+def test_diagnostic_rejects_auth_beside_certificate_inputs():
+    from smartthings_local.protocol.auth import PskAuth
+
+    auth = PskAuth(identity=bytes(range(1, 17)), key=b'k' * 16)
+    for credentials in (
+        {'cert_pem': 'pem', 'key_pem': 'key'},
+        {'cert_path': '/dev/null', 'key_path': '/dev/null'},
+    ):
+        with pytest.raises(ValueError, match='not both'):
+            p.diagnose_dtls_handshake(
+                '127.0.0.1', 5684, auth=auth, **credentials
+            )
+
+
+def test_diagnostic_rejects_an_object_that_is_not_a_provider():
+    with pytest.raises(TypeError, match='AuthenticationProvider'):
+        p.diagnose_dtls_handshake('127.0.0.1', 5684, auth=object())
+
+
+def test_cli_psk_credential_requires_the_diagnostic_mode(capsys):
+    result = p._main([
+        '127.0.0.1', '5684',
+        '--psk-identity', '000102030405060708090a0b0c0d0e0f',
+        '--psk-key', '00' * 16,
+    ])
+
+    assert result == 2
+    assert 'requires the explicit --diagnostic mode' in capsys.readouterr().out
+
+
+def test_cli_psk_credential_needs_both_halves(capsys):
+    result = p._main([
+        '127.0.0.1', '5684', '--diagnostic',
+        '--psk-identity', '000102030405060708090a0b0c0d0e0f',
+    ])
+
+    assert result == 2
+    assert 'must be supplied together' in capsys.readouterr().out
+
+
+def test_cli_refuses_a_certificate_and_a_psk_together(capsys):
+    result = p._main([
+        '127.0.0.1', '5684', '--diagnostic',
+        '--cert', 'c.pem', '--key', 'k.pem',
+        '--psk-identity', '000102030405060708090a0b0c0d0e0f',
+        '--psk-key', '00' * 16,
+    ])
+
+    assert result == 2
+    assert 'not both' in capsys.readouterr().out
+
+
+def test_cli_reports_an_unusable_psk_credential_without_a_traceback(capsys):
+    # A NUL in the identity is rejected by PskAuth, and the CLI has to render
+    # that as a usage error rather than an exception.
+    result = p._main([
+        '127.0.0.1', '5684', '--diagnostic',
+        '--psk-identity', '0102030405060708000a0b0c0d0e0f10',
+        '--psk-key', '00' * 16,
+    ])
+
+    assert result == 2
+    assert 'invalid PSK credential' in capsys.readouterr().out

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -7,6 +7,8 @@ import inspect
 import re
 from pathlib import Path
 
+import pytest
+
 from smartthings_local.ocf.observe_refresh import ObserveRefreshTask
 from smartthings_local.ocf.state_cache import StateCache
 from smartthings_local.protocol.auth import (
@@ -17,6 +19,7 @@ from smartthings_local.protocol.auth import (
     SamsungServerRole,
     ServerCertificateAuth,
 )
+from smartthings_local.protocol.dtls_probe import diagnose_dtls_handshake
 from smartthings_local.protocol.dtls_session import (
     ConnectCancellation,
     DtlsCoapSession,
@@ -275,6 +278,36 @@ def test_known_host_multicast_discovery_has_a_bounded_explicit_interface_api():
     )
     assert result.found is True
     assert result.ports == (43123,)
+
+
+def test_diagnostic_handshake_accepts_any_authentication_provider():
+    parameters = inspect.signature(diagnose_dtls_handshake).parameters
+    assert list(parameters) == [
+        "host",
+        "port",
+        "auth",
+        "cert_pem",
+        "key_pem",
+        "cert_path",
+        "key_path",
+        "retries",
+        "timeout",
+        "mtu",
+        "family",
+    ]
+    for name in ("auth", "cert_pem", "key_pem", "cert_path", "key_path"):
+        assert parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameters[name].default is None
+
+    # A carrier and a raw certificate are alternatives, never a merge.
+    with pytest.raises(ValueError):
+        diagnose_dtls_handshake(
+            "127.0.0.1",
+            5684,
+            auth=PskAuth(identity=bytes(range(1, 17)), key=b"k" * 16),
+            cert_pem="pem",
+            key_pem="key",
+        )
 
 
 def test_certificate_auth_is_a_public_authentication_provider():


### PR DESCRIPTION

`diagnose_dtls_handshake` took certificate credentials and nothing else. LocalThings' `_diagnostic_alert` is the one call site that cannot route through the provider-based session seam being built in localthings#418, and a PSK config entry gets no alert diagnosis at all. mbillow recorded both as gap 3 on localthings#435 and named the second as part of why #418 and #421 are parked.

## What changed

`auth=` accepts any authentication provider, mutually exclusive with `cert_pem`/`key_pem`/`cert_path`/`key_path`, which keep working unchanged. Context construction moves into `_diagnostic_context`, which applies the probe's baseline, then the provider, then re-asserts accept-any verification.

That last step is the one judgement call. Providers configure a context to *gate* on trust: `CertificateAuth` installs OpenSSL's own verdict, and a `SamsungServerProfile` pins a server identity from inside the verify callback. Either one turns an appliance's alert into a local verify failure, which is the single thing a diagnostic must not do. On a #16 or #20 device the `unknown_ca` coming back *from the appliance* is the whole finding. So a diagnostic never enforces trust, including a profile's pinned identity, and the docstring says so and points at `DtlsCoapSession` for the case where the trust decision is the point.

The ordering falls out of the same seam: the provider runs after the baseline, so `PskAuth`'s `ECDHE-PSK-AES128-CBC-SHA256` replaces the ECDHE-ECDSA list. Reverse those two lines and the baseline wins. A test parses the cipher suites out of the ClientHello both ways to hold it.

`unknown_psk_identity(115)` joins `_ALERT_NAMES`. It is the alert a PSK carrier fails with, and it was rendering as the string `'115'`.

The CLI gains `--psk-identity HEX --psk-key HEX`, gated behind `--diagnostic` like `--cert`. A command line is readable by every process on the host, so the usage text says to pass a throwaway value.

## Three visible changes for existing callers

Everything else is untouched: `DtlsCoapSession` and the three stateless probe entry points are not modified, and the certificate branch runs the same sequence of calls, with the accept-any callback moving from a per-call lambda to a named function. Both test files are purely additive, 354 and 33 inserted lines against zero deleted, so every test written against the old behaviour still passes unmodified.

Two things do move, both deliberately:

- **Alert 115 now names itself.** `_ALERT_NAMES` is shared with `probe_dtls_port` and `probe()`, so a caller meeting a device that sends alert 115 saw the string `'115'` before and sees `'unknown_psk_identity'` now.
- **One CLI message is broader.** Passing a credential without `--diagnostic` printed `--cert/--key require the explicit --diagnostic mode` and now prints `a credential requires the explicit --diagnostic mode`, since it covers both credential kinds. Nothing in the tree referenced the old string.
- **`handshake_msgs` is shorter, and truthful.** It used to carry names read out of encrypted records, so a completed handshake ended in junk like `hs189` and could report a message the server never sent. It now holds the plaintext flight alone. `NewSessionTicket` appears where a bare `hs4` did. Nothing in this repository read those entries, and LocalThings' `_resolve_alert` reads `result.alert`, so it is unaffected. A caller inspecting `handshake_msgs` will see the difference.

## Why the tests look the way they do

`_FakeSock` fakes only the datagram transport, so an OpenSSL server driven through its responder emits the flights a device would. The certificate tests verify a real chain, and the PSK test gets OpenSSL's own `unknown_psk_identity` off a server callback that refuses every identity.

Deleting the verify re-assertion fails two of them, which is what makes the guarantee above a measurement.

Running them found a bug worth its own commit. A handshake record after ChangeCipherSpec is encrypted, so its first byte is ciphertext, and `classify_datagram` was reading that byte as a message type. Around one byte in 256 collides with a name in `_HS_NAMES`, so `handshake_msgs` could report a message the server never sent: over 30 loopback handshakes it fabricated a `Finished` once, which is how the flakiness surfaced. `record_datagram` now stops naming handshake messages once it has seen a ChangeCipherSpec. 200 consecutive handshakes on the floor pins give one identical flight, against 1-in-30 variation before.

That in turn exposed a missing entry. Type 4, `NewSessionTicket`, arrives in the clear ahead of the server's ChangeCipherSpec, so a completed handshake legitimately reports it, and it had no name. It has one now.

## Validation

781 tests pass on both CI dependency sets: cbor2 5.6.0 / pyOpenSSL 23.1.0 / pytest 8.0.0, and current releases. `smartthings_local/` gains no dependency, and existing callers are untouched: `_diagnostic_alert` keeps working on `cert_pem`/`key_pem` at whatever version a user has, and can pass a provider once this ships.
