### PR TITLE
Say why a NUL in a PSK identity is refused

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,11 +432,18 @@ auth = PskAuth(identity=psk_identity, key=psk_key)
 sess = DtlsCoapSession("192.0.2.100", 49154, auth=auth)
 ```
 
-The identity must be the raw 16-byte OCF UUID and cannot contain a NUL byte;
-the key must be exactly 16 or 32 bytes. `PskAuth` selects only
-`ECDHE-PSK-AES128-CBC-SHA256` and does not acquire, derive, provision, rotate,
-or persist credentials. Ownership transfer and credential discovery are
-outside this package.
+The identity must be the raw 16-byte OCF UUID and the key exactly 16 or 32 bytes. `PskAuth` selects only `ECDHE-PSK-AES128-CBC-SHA256` and does not acquire, derive, provision, rotate, or persist credentials. Ownership transfer and credential discovery are outside this package.
+
+An identity containing a zero byte is rejected, and that limit is OpenSSL's rather than the appliance's. An OCF device takes the identity as bytes with an explicit length, so a zero byte means nothing to it, but OpenSSL's DTLS 1.2 PSK client callback returns the identity as a C string. Measured against OpenSSL 4.0.0, a 16-byte identity with a NUL at byte 8 reaches the wire as 8 bytes and the handshake raises nothing locally, so the appliance answers a truncated identity it has never seen. DTLS 1.2 offers no length-carrying PSK callback to fall back on, which leaves such a credential unusable through this library: roughly 6% of uniformly random 16-byte identities, and about 5% of UUIDv4s, whose version and variant bytes can never be zero.
+
+Code holding a credential can check it, and report why, before building a provider or storing anything:
+
+```python
+try:
+    PskAuth.validate_identity(psk_identity)
+except (TypeError, ValueError) as exc:
+    print(f"unusable PSK identity: {exc}")
+```
 
 Code that has already completed an authenticated manufacturer-certificate
 session can derive IoTivity's 128-bit OwnerPSK from the resulting TLS state:

--- a/smartthings_local/protocol/auth.py
+++ b/smartthings_local/protocol/auth.py
@@ -556,8 +556,9 @@ class CertificateAuth:
 class PskAuth:
     """DTLS authentication using an existing OCF PSK credential.
 
-    The identity must be a raw 16-byte OCF UUID. The key must contain 16 or
-    32 bytes. Credential material is intentionally not exposed as public
+    The identity must be a raw 16-byte OCF UUID that OpenSSL can present, as
+    described on :meth:`validate_identity`. The key must contain 16 or 32
+    bytes. Credential material is intentionally not exposed as public
     attributes and is never included in this provider's representation. A
     configured context must not outlive this provider; ``DtlsCoapSession``
     enforces that lifetime by retaining its provider.
@@ -565,13 +566,40 @@ class PskAuth:
 
     __slots__ = ("_callback",)
 
-    def __init__(self, *, identity: bytes, key: bytes) -> None:
-        if type(identity) is not bytes or type(key) is not bytes:
-            raise TypeError("identity and key must be bytes")
+    @staticmethod
+    def validate_identity(identity: bytes) -> None:
+        """Raise unless ``identity`` is one OpenSSL can put on the wire.
+
+        A caller holding a credential can check it here, and report the
+        reason, before building a provider or storing anything.
+
+        An OCF appliance takes the identity as bytes with an explicit length,
+        so a zero byte is unremarkable to the device. OpenSSL's DTLS 1.2 PSK
+        client callback returns the identity as a C string, which leaves no
+        way to express one: a NUL truncates the identity on the wire, and the
+        handshake then fails against the truncated value with no local error
+        to point at the cause. Roughly 6% of uniformly random 16-byte
+        identities carry a zero byte, and about 5% of UUIDv4s, whose version
+        and variant bytes can never be zero. There is no length-carrying PSK
+        callback for DTLS 1.2 to fall back on, so such a credential cannot be
+        used through this library.
+        """
+        if type(identity) is not bytes:
+            raise TypeError("identity must be bytes")
         if len(identity) != 16:
             raise ValueError("identity must be a raw 16-byte OCF UUID")
         if b"\x00" in identity:
-            raise ValueError("identity cannot contain a NUL byte")
+            raise ValueError(
+                "identity cannot contain a NUL byte: OpenSSL presents a "
+                "DTLS 1.2 PSK identity as a C string, so a NUL truncates it "
+                "and the appliance would be sent a shorter identity than the "
+                "one supplied"
+            )
+
+    def __init__(self, *, identity: bytes, key: bytes) -> None:
+        if type(identity) is not bytes or type(key) is not bytes:
+            raise TypeError("identity and key must be bytes")
+        self.validate_identity(identity)
         if len(key) not in (16, 32):
             raise ValueError("key must be 16 or 32 bytes")
 

--- a/tests/test_psk_auth.py
+++ b/tests/test_psk_auth.py
@@ -89,6 +89,57 @@ def test_psk_auth_rejects_identity_with_nul_byte():
         PskAuth(identity=b"i" * 15 + b"\x00", key=_KEY)
 
 
+def test_nul_rejection_explains_the_truncation_it_prevents():
+    # Measured against OpenSSL 4.0.0: a 16-byte identity with a NUL at byte 8
+    # goes on the wire as 8 bytes and the handshake raises nothing locally, so
+    # the guard is the only thing standing between a caller and a silently
+    # wrong identity. The message has to carry that, because an appliance
+    # answers the truncated value with unknown_psk_identity and nothing else
+    # points back here.
+    with pytest.raises(ValueError) as raised:
+        PskAuth(identity=b"i" * 15 + b"\x00", key=_KEY)
+
+    message = str(raised.value)
+    assert "C string" in message
+    assert "truncates" in message
+    assert "shorter identity" in message
+
+
+def test_validate_identity_checks_a_credential_before_one_is_assembled():
+    # An import flow holds an identity before it has a provider to build, and
+    # needs the reason to show a user, so the check is reachable on its own
+    # and raises what the constructor raises.
+    assert PskAuth.validate_identity(_IDENTITY) is None
+
+    with pytest.raises(ValueError, match="cannot contain a NUL"):
+        PskAuth.validate_identity(b"i" * 15 + b"\x00")
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [b"i" * 15 + b"\x00", b"i" * 15, b"i" * 17, b""],
+)
+def test_validate_identity_rejects_what_the_constructor_rejects(identity):
+    # One code path, so the reason a caller can show a user is the same
+    # reason the constructor would have raised.
+    with pytest.raises(ValueError) as from_check:
+        PskAuth.validate_identity(identity)
+    with pytest.raises(ValueError) as from_constructor:
+        PskAuth(identity=identity, key=_KEY)
+
+    assert str(from_check.value) == str(from_constructor.value)
+
+
+@pytest.mark.parametrize("identity", ["i" * 16, bytearray(_IDENTITY)])
+def test_validate_identity_names_only_the_argument_it_takes(identity):
+    # The constructor checks both credentials together, so its message names
+    # both. This check takes no key and must not mention one.
+    with pytest.raises(TypeError, match="^identity must be bytes$"):
+        PskAuth.validate_identity(identity)
+    with pytest.raises(TypeError, match="identity and key must be bytes"):
+        PskAuth(identity=identity, key=_KEY)
+
+
 @pytest.mark.parametrize("key_length", [0, 15, 17, 31, 33])
 def test_psk_auth_rejects_invalid_key_lengths(key_length):
     with pytest.raises(ValueError, match="16 or 32 bytes"):

--- a/tests/test_psk_auth.py
+++ b/tests/test_psk_auth.py
@@ -429,3 +429,120 @@ def test_psk_handshake_rejection_does_not_expose_credentials():
     assert _IDENTITY.decode() not in rendered
     assert _KEY.decode() not in rendered
     udp_socket.close.assert_called_once_with()
+
+
+# --- why the NUL guard exists, characterized against OpenSSL -------------
+
+_PSK_CIPHER = b"ECDHE-PSK-AES128-CBC-SHA256:@SECLEVEL=0"
+_CLIENT_CALLBACK_CDEF = (
+    "unsigned int(*)(SSL *, const char *, char *, unsigned int, "
+    "unsigned char *, unsigned int)"
+)
+_SERVER_CALLBACK_CDEF = (
+    "unsigned int(*)(SSL *, const char *, unsigned char *, unsigned int)"
+)
+
+
+def _psk_identity_on_the_wire(identity):
+    """Return the psk_identity length and bytes a real DTLS client sends.
+
+    Both endpoints are OpenSSL over memory BIOs, relayed by hand so the
+    client's records can be read. The ClientKeyExchange carrying
+    psk_identity precedes ChangeCipherSpec, so it is in the clear.
+    """
+    ffi, lib = auth_module._util.ffi, auth_module._util.lib
+
+    @ffi.callback(_CLIENT_CALLBACK_CDEF)
+    def client_callback(_ssl, _hint, identity_buffer, max_identity_length,
+                        key_buffer, max_key_length):
+        # Byte for byte what PskAuth's own callback does, so this measures
+        # OpenSSL rather than a straw man.
+        if len(identity) + 1 > max_identity_length or len(_KEY) > max_key_length:
+            return 0
+        ffi.memmove(identity_buffer, identity + b"\x00", len(identity) + 1)
+        ffi.memmove(key_buffer, _KEY, len(_KEY))
+        return len(_KEY)
+
+    @ffi.callback(_SERVER_CALLBACK_CDEF)
+    def server_callback(_ssl, _identity, key_buffer, max_key_length):
+        if len(_KEY) > max_key_length:
+            return 0
+        ffi.memmove(key_buffer, _KEY, len(_KEY))
+        return len(_KEY)
+
+    client_context = SSL.Context(SSL.DTLS_METHOD)
+    client_context.set_cipher_list(_PSK_CIPHER)
+    lib.SSL_CTX_set_psk_client_callback(
+        client_context._context, client_callback
+    )
+    server_context = SSL.Context(SSL.DTLS_METHOD)
+    server_context.set_cipher_list(_PSK_CIPHER)
+    lib.SSL_CTX_set_psk_server_callback(
+        server_context._context, server_callback
+    )
+
+    client = SSL.Connection(client_context, None)
+    server = SSL.Connection(server_context, None)
+    client.set_connect_state()
+    server.set_accept_state()
+
+    sent = bytearray()
+    for _ in range(30):
+        for source, destination, record in (
+            (client, server, sent),
+            (server, client, None),
+        ):
+            try:
+                source.do_handshake()
+            except (SSL.WantReadError, SSL.Error):
+                pass
+            try:
+                data = source.bio_read(65536)
+            except SSL.WantReadError:
+                continue
+            if record is not None:
+                record += data
+            destination.bio_write(data)
+
+    stream = bytes(sent)
+    offset = 0
+    while offset + 13 <= len(stream):
+        length = int.from_bytes(stream[offset + 11:offset + 13], "big")
+        fragment = stream[offset + 13:offset + 13 + length]
+        offset += 13 + length
+        if len(fragment) >= 14 and fragment[0] == 16:   # ClientKeyExchange
+            body = fragment[12:]
+            declared = int.from_bytes(body[:2], "big")
+            return declared, body[2:2 + declared]
+    raise AssertionError("no ClientKeyExchange reached the wire")
+
+
+def test_openssl_sends_a_clean_identity_whole():
+    # The control: without a NUL, the full 16 bytes arrive.
+    identity = bytes(range(1, 17))
+
+    declared, wire = _psk_identity_on_the_wire(identity)
+
+    assert declared == 16
+    assert wire == identity
+
+
+def test_a_nul_identity_would_reach_the_wire_truncated():
+    # The reason PskAuth refuses this rather than passing it through.
+    # OpenSSL's DTLS 1.2 PSK client callback returns the identity as a
+    # C string and takes its strlen, so everything from the NUL onward is
+    # dropped and nothing raises. An appliance would be asked to
+    # authenticate an identity it has never held, and answer
+    # unknown_psk_identity, with no local error pointing back here.
+    #
+    # If this test ever fails because the full 16 bytes arrive, OpenSSL has
+    # gained a length-carrying path and the guard below can be revisited.
+    identity = bytes(range(1, 9)) + b"\x00" + bytes(range(10, 17))
+
+    declared, wire = _psk_identity_on_the_wire(identity)
+
+    assert declared == 8
+    assert wire == identity[:8]
+
+    with pytest.raises(ValueError, match="cannot contain a NUL"):
+        PskAuth(identity=identity, key=_KEY)

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -7,6 +7,8 @@ import inspect
 import re
 from pathlib import Path
 
+import pytest
+
 from smartthings_local.ocf.observe_refresh import ObserveRefreshTask
 from smartthings_local.ocf.state_cache import StateCache
 from smartthings_local.protocol.auth import (
@@ -348,6 +350,18 @@ def test_psk_auth_is_a_public_authentication_provider():
         and parameter.default is inspect.Parameter.empty
         for parameter in parameters.values()
     )
+
+
+def test_psk_identity_validation_is_reachable_without_a_key():
+    # An import flow validates a stored identity before it has a key to pair
+    # with it, so this is part of the supported surface rather than an
+    # internal guard.
+    parameters = inspect.signature(PskAuth.validate_identity).parameters
+    assert list(parameters) == ["identity"]
+    assert PskAuth.validate_identity(b"i" * 16) is None
+
+    with pytest.raises(ValueError):
+        PskAuth.validate_identity(b"i" * 15 + b"\x00")
 
 
 def test_owner_psk_derivation_keeps_every_security_input_explicit():


### PR DESCRIPTION

`PskAuth` refused an identity containing a zero byte with a bare `identity cannot contain a NUL byte`, which reads as this library being fussy. It is OpenSSL's constraint, and I went in expecting to lift it. Measuring it showed the opposite: the guard is the only thing standing between a caller and a silently wrong identity on the wire.

localthings#435 records this as gap 4, described there as "luck of the draw for an OwnerPSK". The measurement below is what that entry needs, and a follow-up comment there will carry it.

## The measurement

Two tests in the suite carry this, so a reviewer can rerun it. Two OpenSSL endpoints complete a real DTLS 1.2 ECDHE-PSK handshake over memory BIOs, relayed by hand so the client's records can be read, and `psk_identity` is parsed out of the ClientKeyExchange, which precedes ChangeCipherSpec and is therefore in the clear. The client callback is byte for byte what `PskAuth` installs, so what it measures is OpenSSL itself.

| identity supplied | on the wire | local error |
| --- | --- | --- |
| `0102…0f10`, 16 bytes, no NUL | 16 bytes, intact | none |
| `01…08` `00` `0a…10`, 16 bytes, NUL at byte 8 | **8 bytes, truncated** | **none** |

OpenSSL's DTLS 1.2 PSK client callback hands the identity back as a `char *` and takes `strlen()` of it, so there is no way to express a length. The truncated identity goes out and the handshake completes locally without complaint.

Both CI dependency sets carry different OpenSSL builds, 4.0.0 under pyOpenSSL 26.2.0 and 3.1.0 under the 23.1.0 floor, and both truncate. The truncation test also asserts that `PskAuth` refuses that exact identity, so the guard and its justification move together. Should the full 16 bytes ever arrive, OpenSSL has gained a length-carrying path and the guard can be revisited, which the test says in place.

The appliance side is fine with a zero byte, and two independent OCF stacks agree on that. Samsung's RT-OCF takes `rt_sec_cred_get_psk(const uint8_t *uuid, size_t uuid_len, ...)`, and mbedTLS hands it `(*p, n)`. iotivity-lite, the maintained reference stack, builds its client identity as `memcpy(identity_hint, device_id->id, 16)` with `identity_hint_len = 16` for `mbedtls_ssl_conf_psk`, and its `get_psk_cb(..., const unsigned char *identity, size_t identity_len)` casts that to `oc_uuid_t *`. Counted bytes throughout, on both. So this is a client-library limit, and lifting the guard would mean presenting a different, shorter identity and reading `unknown_psk_identity` back with nothing pointing at the cause.

TLS 1.3's `psk_find_session` and `psk_use_session` callbacks do carry arbitrary-length identities, and both setters are present in the binding, but they are TLS 1.3 only. These appliances are DTLS 1.2, so the credential is unreachable here: roughly 6% of uniformly random 16-byte identities, and about 5% of UUIDv4s, whose version and variant bytes can never be zero.

## What changed

The guard stays. The message now names the cause and the consequence, so it survives being surfaced to a user who has to act on it.

`PskAuth.validate_identity(identity)` exposes the same check to a caller holding a credential before it has a key to pair with it. An import flow can then refuse at import time and show the reason, at the point where a user can still act on it. The constructor delegates to it, so there is one code path and one message.

The constructor still reports `identity and key must be bytes`, since it checks both together. `validate_identity` takes one argument and says `identity must be bytes`. A test holds that distinction, so sharing the path keeps both messages accurate.

One boundary that came out of reading iotivity-lite: its random-PIN OTM uses a 33-byte identity, `"oic.sec.doxm.rdp:"` followed by the 16 raw UUID bytes, so an OCF identity is not always 16 bytes. `PskAuth` requires exactly 16, which is right for a runtime credential and cannot express the PIN-OTM shape. Onboarding is out of scope, so I read that as a scope decision, though anyone reaching for the RDP path later will meet this length check.

## Validation

780 tests pass on both CI dependency sets: cbor2 5.6.0 / pyOpenSSL 23.1.0 / pytest 8.0.0, and current releases. `check_share_safety.py` is clean.

One overlap with #84: both branches add `import pytest` to `tests/test_public_api_contract.py`. Whichever merges second may want a one-line rebase.
