### PR TITLE
Move the bridge demo into its own document

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`smartthings-local` is a Python library for local, cloud-free control of Samsung connected appliances over authenticated CoAP-DTLS.** It gives you the DTLS-CoAP transport, a tiered polling + OBSERVE state layer, and identity-cert tooling for AC14K_M-compatible firmware. Newer OCF-PKI appliances require a different authentication profile; see [the laundry compatibility findings](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/ocf-pki-laundry.md). Supported profiles can read state and write commands on the LAN with no SmartThings cloud round-trip.
 
-The repo also ships a self-contained **reference bridge demo** (`mqtt_demo/`) that turns the library into auto-discovered Home Assistant entities over MQTT. One process supervises multiple appliances, each on its own DTLS session.
+The repo also ships a self-contained **reference bridge demo** (`mqtt_demo/`) that turns the library into auto-discovered Home Assistant entities over MQTT. One process supervises multiple appliances, each on its own DTLS session. Configuration, deployment and per-appliance coverage are in [`docs/bridge-demo.md`](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/bridge-demo.md).
 
 <img width="778" height="367" alt="image" src="https://github.com/user-attachments/assets/cc1dca15-f272-4625-a13c-2dc82283ff95" />
 
@@ -16,6 +16,7 @@ The repo also ships a self-contained **reference bridge demo** (`mqtt_demo/`) th
 ## Documentation
 
 - **[`docs/api.md`](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/api.md)** — the supported API: every name downstream code may import, with its signature. Generated from the code, so it cannot drift.
+- **[`docs/bridge-demo.md`](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/bridge-demo.md)** — the MQTT bridge demo: what it exposes, how to configure and deploy it, per-appliance coverage, config keys and topics.
 - [`docs/ocf-pki-laundry.md`](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/ocf-pki-laundry.md) — the newer OCF-PKI appliance generation, and why an AC14K_M certificate is refused there.
 - [`docs/ocf-vd-devices.md`](https://github.com/QuiteYellow/SmartThings-Local/blob/main/docs/ocf-vd-devices.md) — server-authenticated findings from Samsung VD hardware.
 
@@ -28,7 +29,7 @@ pip install smartthings-local
 ```
 
 For compatible firmware, mint a client cert once (see
-[Part 2](#part-2--auth-for-ac14k_m-compatible-firmware)), then drive a
+[Auth for AC14K_M-compatible firmware](#auth-for-ac14k_m-compatible-firmware)), then drive a
 session directly:
 
 ```python
@@ -526,6 +527,12 @@ The helper performs deterministic key derivation only: it does not access a
 session, discover credentials, choose an ownership method, write security
 resources, run OTM, or persist the result.
 
+## Library reference
+
+The sections below cover the rest of the library surface: the error types a
+call can raise, endpoint resolution, and the two bounded plaintext reads used
+to find an appliance before authenticating to it.
+
 ### Classified errors
 
 Runtime transport failures use the public types in
@@ -657,27 +664,7 @@ successful representations; they are `None` for a non-success diagnostic body.
 
 For a full worked integration, the higher-level `smartthings_local.ocf` layer (`StateCache`, `PollScheduler`, `KeepaliveTask`, `ObserveRefreshTask`) coordinates tiered polling and OBSERVE on top of a session. The MQTT bridge demo below wires all of it together.
 
-### What the demo bridge gives you
-
-- **Multi-appliance, one container:** single Docker service holds N DTLS sessions in parallel, one per appliance, sharing one MQTT client. Adding an appliance class is ~150 lines and one descriptor file.
-- **Bounded state latency:** hot-tier resources (job state, door, operational state) refresh on a sub-second cadence regardless of whether the appliance has internet. Worst-case lag is the tier interval (≤1s idle, ≤500ms during an active cycle on the dryer).
-- **Writes that work:** dryer Start/Pause/Stop, course selection, wrinkle prevent; oven lamp (light entity), sound, fast preheat, setpoint slider, mode select, stop.
-- **Optimistic publish + verify:** HA sees the new value the instant the device 2.04-confirms the write; the PollScheduler verifies on its next tier tick (after a 4s defer past Samsung's fetchback-revert window).
-- **HA Energy Dashboard ready** (dryer): live watts + cumulative kWh as `total_increasing`.
-- **Bridge logs tagged per-appliance** with `<class>.<serial>` once each device's serial is read on connect: `dryer.<serial>` and `oven.<serial>` interleave in the same log stream, easy to grep.
-- **Zero HA YAML:** every entity is auto-discovered via MQTT discovery.
-- **Your state stays on your LAN:** bridge → broker → HA. Samsung's cloud sees nothing from HA. *(The appliance still maintains its own TLS session to Samsung. That's the appliance's design, not ours.)*
-- **A few controls the cloud HA integration doesn't offer.** Talking to the appliance directly surfaces some writes the official SmartThings integration doesn't currently expose for these models: dryer course selection ([HA core #162501](https://github.com/home-assistant/core/issues/162501)) and the oven temperature setpoint (where the cloud integration provides a read-only sensor). It's not a strict superset (the cloud integration still covers surfaces this doesn't), but the reverse-engineered write set is broad.
-
-### Under the hood
-
-Each appliance runs an independent bridge built around three coordinated pieces over one persistent DTLS session: a `StateCache` (single source of truth for all reps), a `PollScheduler` (tiered adaptive polling: hot/warm/cold plus a periodic `/device/0` sweep), and a `KeepaliveTask` (CoAP empty-CON ping for DTLS-layer liveness, with consecutive-failure detection for MQTT availability). Tier cadences are descriptor-declared and were calibrated against the empirically-measured per-firmware ceilings: dryer ~14 req/s, oven ~8 req/s. OBSERVE registrations (RFC 7641) are kept as an opportunistic freshness accelerator: when the appliance has internet and emits notifications, the cache absorbs them and the next-poll timer is reset for that resource; when it's air-gapped, polling alone carries the UX with no other code change. Token-stable Block2 (RFC 7959) handles multi-block reads. Writes are optimistically merged into the cache the moment the device 2.04-confirms, with the scheduler deferring that resource's next poll past the fetchback-revert window. Reconnect with exponential backoff on session errors, gated by a stateless DTLS ClientHello pre-flight (`smartthings_local/protocol/dtls_probe.py`) so a silent/rebooting device or wrong port drops into backoff in ~1 RTT instead of eating the full handshake timeout; when `OCF_PORT` is unset the same probe auto-discovers the live port across the OCF band.
-
-On the currently supported firmware families, authentication uses a client cert keyed to the UUID published in Samsung's own wildcard cloud TLS cert. Their factory ACL grants that UUID `perm=31` (full CRUDN) on `href=*`. That certificate path is not universal: the WD53 profile in issue #16 and the washer in issue #20 reject it. For those newer OCF-PKI devices, the `SamsungServerProfile` and `ServerCertificateAuth` providers (see Quick start) pin and verify the device's hardware certificate, but getting an authorized client credential to reach protected resources is still an open problem.
-
----
-
-## Part 1 — Is your appliance compatible?
+## Is your appliance compatible?
 
 Check before anything else; if it's older firmware, this project doesn't target it.
 
@@ -699,7 +686,7 @@ nmap's `open|filtered` can't tell a real DTLS server from a silent UDP port. Con
 python -m smartthings_local.protocol.dtls_probe "$APPLIANCE_IP" 5684 49153 49154 49155 49156 --stateless
 ```
 
-`live` means a DTLS server answered its first flight; `dead` means silent or not DTLS. Once you have the client cert (Part 2), add the explicit `--diagnostic` flag to run the stateful diagnostic drive, which reports `completed` (cert accepted) or `rejected` with the server's fatal alert. Diagnostic mode can allocate appliance-side DTLS state and is never used by discovery or reconnect. An `unsupported_certificate` / `unknown_ca` alert means the endpoint is reachable but this certificate profile was rejected. It is not a reason to disable verification or keep retrying. The same bounded stateless API gates the bridge's reconnect loop and, when `OCF_PORT` is unset, probes both standard 5684 and ports 49152–49160.
+`live` means a DTLS server answered its first flight; `dead` means silent or not DTLS. Once you have the client cert (see [Auth for AC14K_M-compatible firmware](#auth-for-ac14k_m-compatible-firmware)), add the explicit `--diagnostic` flag to run the stateful diagnostic drive, which reports `completed` (cert accepted) or `rejected` with the server's fatal alert. Diagnostic mode can allocate appliance-side DTLS state and is never used by discovery or reconnect. An `unsupported_certificate` / `unknown_ca` alert means the endpoint is reachable but this certificate profile was rejected. It is not a reason to disable verification or keep retrying. The same bounded stateless API gates the bridge's reconnect loop and, when `OCF_PORT` is unset, probes both standard 5684 and ports 49152–49160.
 
 A device that rejects the certificate profile may still run a PSK endpoint, and `diagnose_dtls_handshake` takes any authentication provider through `auth=` so that carrier can be characterised the same way:
 
@@ -797,7 +784,7 @@ Which path is doing the work is visible in Home Assistant. The bridge publishes 
 
 ---
 
-## Part 2 — Auth for AC14K_M-compatible firmware
+## Auth for AC14K_M-compatible firmware
 
 For a compatible firmware family, the bridge authenticates with a **client
 cert** signed by `AC14K_M`, an intermediate CA that has been public for years.
@@ -858,232 +845,7 @@ extrapolate this certificate path to an untested model.
 
 ---
 
-## Part 3 — Configure your appliances
-
-Copy `.env.example` to `.env` and fill in.
-
-### Layered envs
-
-The bridge config splits into:
-
-- **Shared keys** (one per process): MQTT broker + creds, HA discovery prefix, cert paths, timer intervals.
-- **Per-appliance keys** (one block per appliance) under `APPLIANCE_<n>_*` (1-indexed).
-
-`APPLIANCE_COUNT` tells the bridge how many indexed blocks to read. Bump it as you add appliances.
-
-```bash
-APPLIANCE_COUNT=2
-
-# Appliance 1 — dryer
-APPLIANCE_1_CLASS=dryer
-APPLIANCE_1_IP=192.0.2.100
-APPLIANCE_1_OCF_PORT=             # blank → auto-discover across the OCF band (dryer=49155)
-APPLIANCE_1_TOPIC=samsung_dryer
-APPLIANCE_1_NAME=Samsung Dryer
-
-# Appliance 2 — oven
-APPLIANCE_2_CLASS=oven
-APPLIANCE_2_IP=192.0.2.101
-APPLIANCE_2_OCF_PORT=             # blank → auto-discover across the OCF band (oven=49154)
-APPLIANCE_2_TOPIC=samsung_oven
-APPLIANCE_2_NAME=Samsung Oven
-```
-
-Each `APPLIANCE_<n>_CLASS` must match a key in
-`mqtt_demo.samples.DESCRIPTORS`: currently `dryer`, `oven`, and `fridge`.
-
----
-
-## Part 4 — Run it
-
-### Docker (the real deployment)
-
-```sh
-docker compose up -d --build
-docker compose logs -f
-```
-
-Container name `smartthings-local`. Outbound-only; no ports exposed. Needs egress to each appliance's IP/port (UDP) and to your MQTT broker. The certs in `./certs/` (or whatever `APPDATA_DIR` points to via the volume mount) are read-only mounted at `/config`.
-
-### Deploying to a remote Linux host (Unraid, etc.)
-
-```sh
-# Once: upload the cert + key onto the remote.
-ssh "$SSH_HOST" mkdir -p "$APPDATA_DIR"
-scp certs/client_fullchain.pem certs/client.key "$SSH_HOST:$APPDATA_DIR/"
-
-# Each deploy: ship source + .env, rebuild container on the host.
-./deploy.sh
-```
-
-Set `SSH_HOST`, `REMOTE_DIR`, `APPDATA_DIR` in `.env`. `deploy.sh` extracts those three keys via `grep` rather than `source .env`, so values containing spaces (like `APPLIANCE_1_NAME=Samsung Dryer`) don't break it.
-
-### Bare metal (first test / debugging)
-
-```sh
-python3 -m venv .venv
-.venv/bin/pip install -r mqtt_demo/requirements.txt
-.venv/bin/python -m mqtt_demo
-```
-
-### Expected first-run logs
-
-```
-14:08:42  INFO   mqtt_demo                SmartThings-Local Bridge starting (2 appliances)
-14:08:42  INFO   mqtt_demo                  broker = <broker-ip>:1883 (user=<mqtt-user>)
-14:08:42  INFO   mqtt_demo                  [1] dryer @ <dryer-ip>:49155? (DTLS, auto-discover) → topic samsung_dryer/*
-14:08:42  INFO   mqtt_demo                  [2] oven  @ <oven-ip>:49154? (DTLS, auto-discover) → topic samsung_oven/*
-14:08:42  INFO   mqtt_demo                MQTT connected → <broker-ip>:1883
-14:08:43  INFO   dryer                    discovered DTLS port 49155
-14:08:43  INFO   oven                     discovered DTLS port 49154
-14:08:43  INFO   dryer                    DTLS connected — subscribing 11 paths
-14:08:44  INFO   dryer.<dryer-serial>     identified — serial=…
-14:08:44  INFO   dryer.<dryer-serial>     seeded → 25 links; sensors live
-14:08:44  INFO   oven                     DTLS connected — subscribing 11 paths
-14:08:46  INFO   oven.<oven-serial>       identified — serial=…
-14:08:46  INFO   oven.<oven-serial>       seeded → 16 links; sensors live
-```
-
-In HA: **Settings → Devices & Services → MQTT** should show both devices populated.
-
----
-
-## Per-appliance notes
-
-### Dryer
-
-| Capability | Works? | Notes |
-|---|---|---|
-| Read all state | ✅ | Machine state, job state, energy (W + kWh), course, dry level, completion time, remote control, child lock, alarms |
-| Wrinkle Prevent toggle | ✅ | Persists |
-| Start / Pause / Stop | ✅ | Via `/operational/state/vs/0`; needs Remote Control on |
-| Change course | ✅ | Via `/st/dryercourse/vs/0`; needs Remote Control on. **Not exposed by the SmartThings cloud HA integration.** |
-| Power on/off | ❌ | Accepted (2.04) but reverts within seconds; hardware-mirrored |
-| Child Lock / Remote Control toggle | ❌ | Same; hardware-mirrored physical buttons |
-
-The dryer's `/operational/state/vs/0` is on the bridge's hot poll tier (1s idle / 0.5s while a cycle is active) and also accepts OBSERVE registration. When the appliance has internet it pushes notifications within ~100ms of any state change and the cache absorbs them as fast freshness; when air-gapped the hot-tier poll carries the same UX with worst-case lag of one tier interval.
-
-### Oven
-
-| Capability | Works? | Notes |
-|---|---|---|
-| Read state | ✅ | Cavity state, current/target temp, door, mode, alarms, firmware-update-available |
-| Lamp (light entity) | ✅ | Binary On/Off only; High/Low/Dim values are accepted (2.04) but silently coerced back. Works regardless of Remote Control. |
-| Sound, Fast preheat | ⚠️ | Wired but untested RC-gated. |
-| Setpoint slider | ⚠️ | Wired but untested RC-gated. |
-| Mode select | ⚠️ | Wired but untested RC-gated. |
-| Stop button | ✅ |  |
-| **Kitchen timer (`⏲` icon)** | ❌ | **The oven's panel kitchen timer is not exposed via CoAP at all.** Confirmed by full `/device/0` dump: `UpperTimer*` fields in `/mode/vs/0` only populate when set via the API, not from the panel. |
-
-**The oven doesn't push OBSERVE on `/mode/vs/0` writes** (the dryer does). The bridge handles this transparently because state freshness comes from polling rather than from OBSERVE:
-1. **Optimistic publish** — the moment a POST returns 2.04, the bridge merges the write body into the cache and publishes to MQTT. HA reflects the new value instantly.
-2. **Scheduler reconciliation** — the PollScheduler defers polling the just-written resource for ~4s (past Samsung's fetchback-revert window), then refreshes it on its tier cadence. If the device silently coerced the value, the corrected state is republished and HA reverts.
-3. **Periodic `/device/0` sweep** — every 5 minutes the scheduler's sweep tier re-fetches the whole device tree, bounding worst-case drift on any resource the per-tier polls don't cover.
-
-### Fridge (ARTIK051)
-
-Contributed by [@aminorjourney](https://github.com/aminorjourney) in PR #1, verified against an `ARTIK051_REF_17K` fridge-freezer on firmware `DA-REF-ART-COMMON-1_20201124`. First public documentation of this firmware's local resource layout.
-
-| Capability | Works? | Notes |
-|---|---|---|
-| Read temperatures | ✅ | Fridge + freezer current + setpoint via `/temperatures/vs/0` |
-| Read doors | ✅ | Fridge, freezer, convertible zone via `/doors/vs/0` items array; plus an "any door open" binary sensor |
-| Energy monitoring | ✅ | Instantaneous W + cumulative Wh via `/energy/consumption/vs/0` |
-| Water filter | ✅ | Usage % + status via `/filter/waterfilter/vs/0` |
-| Ice maker | ✅ | State + ice-making status via `/icemaker/one/vs/0` |
-| Setpoint slider (fridge / freezer) | ✅ | Fridge 1–7°C, freezer -23 to -15°C |
-| Power Cool, Power Freeze, Sabbath, Ice Maker switches | ✅ | |
-| Active modes | ✅ | Read-only sensor of the fridge's mode list |
-
-Notes specific to this firmware family:
-- **Port 49155**, not the 49154 the oven defaults to.
-- `/oic/res` only advertises 15 paths; the full resource tree lives at `/device/0` (32 links). The bridge's periodic `/device/0` sweep handles this transparently; no descriptor change needed.
-- `/hass/state/vs/0` and `/hass/command/vs/0` return `4.04`. They're vestigial paths from an earlier firmware and are ignored.
-- Doors are exposed as a Samsung-plural collection resource (`/doors/vs/0` with an `items[]` array keyed by `x.com.samsung.da.description`), not as per-room OCF resources like the newer RF9000B-class fridges use. This is one of the concrete divergences behind the "Firmware families" caveat in Part 1.
-
----
-
-## Reference
-
-### Config keys
-
-| Key | Meaning |
-|---|---|
-| `APPLIANCE_COUNT` | Number of `APPLIANCE_<n>_*` blocks to read (1-indexed) |
-| `APPLIANCE_<n>_CLASS` | Descriptor name: `dryer`, `oven`, `fridge` |
-| `APPLIANCE_<n>_IP` | LAN IP of the appliance |
-| `APPLIANCE_<n>_OCF_PORT` | Optional. Blank → probe standard port 5684 and the dynamic range 49152–49160 with a stateless ClientHello; set it to pin and gate one specific port (dryer=49155, oven=49154, fridge=49155) |
-| `APPLIANCE_<n>_TOPIC` | MQTT topic prefix (also the HA device identifier; changing it re-keys the device) |
-| `APPLIANCE_<n>_NAME` | Friendly name on the HA device card |
-| `MQTT_BROKER` / `MQTT_PORT` / `MQTT_USER` / `MQTT_PASS` | Broker config |
-| `HA_DISCOVERY_PREFIX` | HA discovery topic root (default `homeassistant`) |
-| `CERT_PATH` / `KEY_PATH` | Override cert lookup (auto-detects `/config/` then `./certs/`) |
-| `HEALTH_INTERVAL_S` | Seconds between `<prefix>/bridge/health` publishes (default 60) |
-| `PING_INTERVAL_S` | CoAP empty-CON ping cadence; three consecutive failures publish `availability=offline` (default 25). Tier polling cadences are descriptor-declared, not env-tunable. |
-| `CLOCK_SYNC_INTERVAL_H` | Hours between appliance clock writes, for descriptors that declare one (default 24; `0` disables the sync and its button) |
-| `SSH_HOST` / `REMOTE_DIR` / `APPDATA_DIR` | Used by `deploy.sh` only |
-
-### MQTT topics — outgoing (bridge → broker)
-
-Per appliance, where `<prefix>` is its `APPLIANCE_<n>_TOPIC`.
-
-| Topic | Retain | When |
-|---|---|---|
-| `<prefix>/availability` | ✓ | `online` after seed; `offline` on disconnect (LWT for appliance #1) |
-| `<prefix>/remote_available` | ✓ | `online` iff bridge is up AND Remote Control on the appliance is on. Gates the control entities. |
-| `<prefix>/state` | ✓ | JSON sensor dict; published only when sensors actually diff |
-| `<prefix>/bridge/health` | ✓ | Every `HEALTH_INTERVAL_S`: connect_count, error_count, notif_count, poll_count, poll_error_count, ping_count, ping_fail_count, reachable, last_change_age_s, last_seed_age_s, session_age_s, stalest_href, stalest_age_s, serial |
-| `<ha_prefix>/{sensor,binary_sensor,switch,light,number,select,button}/<prefix>/.../config` | ✓ | HA MQTT discovery, republished on every MQTT (re)connect |
-
-### MQTT topics — incoming (bridge subscribes)
-
-`<prefix>/cmd/#`. **The MQTT user must have READ permission on this subtree.** Without it the broker silently drops the TCP connection shortly after SUBSCRIBE. Check broker logs if writes never land.
-
-Dryer:
-
-| Suffix | Payloads | Effect |
-|---|---|---|
-| `cmd/wrinkle_prevent` | `On`, `Off` | POST `/washer/vs/0` |
-| `cmd/operational_state` | `Run`, `Pause`, `Ready` | POST `/operational/state/vs/0`; requires RC |
-| `cmd/dryer_mode` | Course name (e.g. `Cotton`) | Translated to `Course_HH` then POST `/st/dryercourse/vs/0`; requires RC |
-
-Oven:
-
-| Suffix | Payloads | Effect |
-|---|---|---|
-| `cmd/lamp` | `On`, `Off` | RMW of `/mode/vs/0 .options[UpperLamp_*]` |
-| `cmd/sound` | `On`, `Off` | RMW of `/mode/vs/0 .options[Sound_*]` |
-| `cmd/fastpreheat` | `On`, `Off` | RMW of `/mode/vs/0 .options[fastpreheat_*]` |
-| `cmd/setpoint` | Integer °C (30–270, step 5) | RMW of `/temperatures/vs/0 .items[0].desired`; requires RC |
-| `cmd/mode` | Mode name (e.g. `Convection`, `LargeGrill`) | POST `/mode/vs/0 {modes: [<name>]}`; requires RC |
-| `cmd/stop` | (button press) | POST `/operational/state/vs/0 {state: Ready}` |
-| `cmd/sync_clock` | (button press) | POST `/configuration/vs/0 {x.com.samsung.da.currentTime: <host local time>}` |
-
-#### Clock sync
-
-An appliance kept off the internet has no way to correct its own clock, so the display drifts. Where a descriptor declares a `ClockSync` spec (today the oven), the bridge writes the host's local wall clock to `/configuration/vs/0` as `x.com.samsung.da.currentTime` every `CLOCK_SYNC_INTERVAL_H` hours, and exposes a Sync clock button for an immediate write. Set `CLOCK_SYNC_INTERVAL_H=0` to switch off both.
-
-The field is write-only: a GET of that resource returns the metadata without it, so the value never enters the state cache and no sensor reports it. Timestamps land in the container's `TZ`.
-
-The write came from LocalThings [#404](https://github.com/mbillow/localthings/issues/404) / [#428](https://github.com/mbillow/localthings/pull/428), verified there on a TP1X range and originally documented on [the SmartThings forum](https://community.smartthings.com/t/samsung-oven-range-and-cooktop-sync-time-api/251391). Both the periodic write and the button answer 2.04 on the oven this repo's sample descriptor targets. Other appliance classes are untested — a rejection shows up as a 4.xx in the bridge log, and nothing else is written to the resource.
-
-One limit is worth knowing whatever the appliance. A timestamp far outside its certificate validity window can break certificate verification and leave it unresponsive, so the bridge refuses to write a host clock reading outside `PLAUSIBLE_FROM`/`PLAUSIBLE_UNTIL` in `mqtt_demo/clock_sync.py`. A host that boots without NTP skips the sync rather than writing 1970.
-
-### Entity counts (approximate, per appliance)
-
-| Type | Dryer | Oven |
-|---|---|---|
-| `sensor` | 17 | 17 |
-| `binary_sensor` | 4 | 7 |
-| `switch` | 1 (wrinkle) | 2 (sound, fastpreheat) |
-| `light` | — | 1 (lamp) |
-| `number` | — | 1 (setpoint slider) |
-| `select` | 1 (course) | 1 (mode) |
-| `button` | 3 (start/pause/stop) | 2 (stop, sync clock) |
-
-Gated control entities use HA's `availability_mode: all` against `<prefix>/availability` AND `<prefix>/remote_available`. Flip Remote Control on the appliance's front panel and those entities un-grey in HA.
-
-### Repo layout
+## Repo layout
 
 ```
 smartthings_local/                   The installable library — `pip install smartthings-local`

--- a/docs/bridge-demo.md
+++ b/docs/bridge-demo.md
@@ -1,0 +1,259 @@
+# Reference bridge demo
+
+`mqtt_demo/` is a self-contained MQTT bridge built on `smartthings-local`. It
+turns the library into auto-discovered Home Assistant entities, supervising
+several appliances from one process with a DTLS session each.
+
+It is a demonstration of the library rather than the recommended way to run
+Samsung appliances in Home Assistant. For that, use
+[localthings](https://github.com/mbillow/localthings), a custom component
+built on this package.
+
+You need a client certificate before any of this works. See
+[Certificates](https://github.com/QuiteYellow/SmartThings-Local/blob/main/README.md#auth-for-ac14k_m-compatible-firmware)
+in the README.
+
+## What the demo bridge gives you
+
+- **Multi-appliance, one container:** single Docker service holds N DTLS sessions in parallel, one per appliance, sharing one MQTT client. Adding an appliance class is ~150 lines and one descriptor file.
+- **Bounded state latency:** hot-tier resources (job state, door, operational state) refresh on a sub-second cadence regardless of whether the appliance has internet. Worst-case lag is the tier interval (≤1s idle, ≤500ms during an active cycle on the dryer).
+- **Writes that work:** dryer Start/Pause/Stop, course selection, wrinkle prevent; oven lamp (light entity), sound, fast preheat, setpoint slider, mode select, stop.
+- **Optimistic publish + verify:** HA sees the new value the instant the device 2.04-confirms the write; the PollScheduler verifies on its next tier tick (after a 4s defer past Samsung's fetchback-revert window).
+- **HA Energy Dashboard ready** (dryer): live watts + cumulative kWh as `total_increasing`.
+- **Bridge logs tagged per-appliance** with `<class>.<serial>` once each device's serial is read on connect: `dryer.<serial>` and `oven.<serial>` interleave in the same log stream, easy to grep.
+- **Zero HA YAML:** every entity is auto-discovered via MQTT discovery.
+- **Your state stays on your LAN:** bridge → broker → HA. Samsung's cloud sees nothing from HA. *(The appliance still maintains its own TLS session to Samsung. That's the appliance's design, not ours.)*
+- **A few controls the cloud HA integration doesn't offer.** Talking to the appliance directly surfaces some writes the official SmartThings integration doesn't currently expose for these models: dryer course selection ([HA core #162501](https://github.com/home-assistant/core/issues/162501)) and the oven temperature setpoint (where the cloud integration provides a read-only sensor). It's not a strict superset (the cloud integration still covers surfaces this doesn't), but the reverse-engineered write set is broad.
+
+## Under the hood
+
+Each appliance runs an independent bridge built around three coordinated pieces over one persistent DTLS session: a `StateCache` (single source of truth for all reps), a `PollScheduler` (tiered adaptive polling: hot/warm/cold plus a periodic `/device/0` sweep), and a `KeepaliveTask` (CoAP empty-CON ping for DTLS-layer liveness, with consecutive-failure detection for MQTT availability). Tier cadences are descriptor-declared and were calibrated against the empirically-measured per-firmware ceilings: dryer ~14 req/s, oven ~8 req/s. OBSERVE registrations (RFC 7641) are kept as an opportunistic freshness accelerator: when the appliance has internet and emits notifications, the cache absorbs them and the next-poll timer is reset for that resource; when it's air-gapped, polling alone carries the UX with no other code change. Token-stable Block2 (RFC 7959) handles multi-block reads. Writes are optimistically merged into the cache the moment the device 2.04-confirms, with the scheduler deferring that resource's next poll past the fetchback-revert window. Reconnect with exponential backoff on session errors, gated by a stateless DTLS ClientHello pre-flight (`smartthings_local/protocol/dtls_probe.py`) so a silent/rebooting device or wrong port drops into backoff in ~1 RTT instead of eating the full handshake timeout; when `OCF_PORT` is unset the same probe auto-discovers the live port across the OCF band.
+
+On the currently supported firmware families, authentication uses a client cert keyed to the UUID published in Samsung's own wildcard cloud TLS cert. Their factory ACL grants that UUID `perm=31` (full CRUDN) on `href=*`. That certificate path is not universal: the WD53 profile in issue #16 and the washer in issue #20 reject it. For those newer OCF-PKI devices, the `SamsungServerProfile` and `ServerCertificateAuth` providers (see Quick start) pin and verify the device's hardware certificate, but getting an authorized client credential to reach protected resources is still an open problem.
+
+---
+
+## Configure your appliances
+
+Copy `.env.example` to `.env` and fill in.
+
+### Layered envs
+
+The bridge config splits into:
+
+- **Shared keys** (one per process): MQTT broker + creds, HA discovery prefix, cert paths, timer intervals.
+- **Per-appliance keys** (one block per appliance) under `APPLIANCE_<n>_*` (1-indexed).
+
+`APPLIANCE_COUNT` tells the bridge how many indexed blocks to read. Bump it as you add appliances.
+
+```bash
+APPLIANCE_COUNT=2
+
+# Appliance 1 — dryer
+APPLIANCE_1_CLASS=dryer
+APPLIANCE_1_IP=192.0.2.100
+APPLIANCE_1_OCF_PORT=             # blank → auto-discover across the OCF band (dryer=49155)
+APPLIANCE_1_TOPIC=samsung_dryer
+APPLIANCE_1_NAME=Samsung Dryer
+
+# Appliance 2 — oven
+APPLIANCE_2_CLASS=oven
+APPLIANCE_2_IP=192.0.2.101
+APPLIANCE_2_OCF_PORT=             # blank → auto-discover across the OCF band (oven=49154)
+APPLIANCE_2_TOPIC=samsung_oven
+APPLIANCE_2_NAME=Samsung Oven
+```
+
+Each `APPLIANCE_<n>_CLASS` must match a key in
+`mqtt_demo.samples.DESCRIPTORS`: currently `dryer`, `oven`, and `fridge`.
+
+---
+
+## Run it
+
+### Docker (the real deployment)
+
+```sh
+docker compose up -d --build
+docker compose logs -f
+```
+
+Container name `smartthings-local`. Outbound-only; no ports exposed. Needs egress to each appliance's IP/port (UDP) and to your MQTT broker. The certs in `./certs/` (or whatever `APPDATA_DIR` points to via the volume mount) are read-only mounted at `/config`.
+
+### Deploying to a remote Linux host (Unraid, etc.)
+
+```sh
+# Once: upload the cert + key onto the remote.
+ssh "$SSH_HOST" mkdir -p "$APPDATA_DIR"
+scp certs/client_fullchain.pem certs/client.key "$SSH_HOST:$APPDATA_DIR/"
+
+# Each deploy: ship source + .env, rebuild container on the host.
+./deploy.sh
+```
+
+Set `SSH_HOST`, `REMOTE_DIR`, `APPDATA_DIR` in `.env`. `deploy.sh` extracts those three keys via `grep` rather than `source .env`, so values containing spaces (like `APPLIANCE_1_NAME=Samsung Dryer`) don't break it.
+
+### Bare metal (first test / debugging)
+
+```sh
+python3 -m venv .venv
+.venv/bin/pip install -r mqtt_demo/requirements.txt
+.venv/bin/python -m mqtt_demo
+```
+
+### Expected first-run logs
+
+```
+14:08:42  INFO   mqtt_demo                SmartThings-Local Bridge starting (2 appliances)
+14:08:42  INFO   mqtt_demo                  broker = <broker-ip>:1883 (user=<mqtt-user>)
+14:08:42  INFO   mqtt_demo                  [1] dryer @ <dryer-ip>:49155? (DTLS, auto-discover) → topic samsung_dryer/*
+14:08:42  INFO   mqtt_demo                  [2] oven  @ <oven-ip>:49154? (DTLS, auto-discover) → topic samsung_oven/*
+14:08:42  INFO   mqtt_demo                MQTT connected → <broker-ip>:1883
+14:08:43  INFO   dryer                    discovered DTLS port 49155
+14:08:43  INFO   oven                     discovered DTLS port 49154
+14:08:43  INFO   dryer                    DTLS connected — subscribing 11 paths
+14:08:44  INFO   dryer.<dryer-serial>     identified — serial=…
+14:08:44  INFO   dryer.<dryer-serial>     seeded → 25 links; sensors live
+14:08:44  INFO   oven                     DTLS connected — subscribing 11 paths
+14:08:46  INFO   oven.<oven-serial>       identified — serial=…
+14:08:46  INFO   oven.<oven-serial>       seeded → 16 links; sensors live
+```
+
+In HA: **Settings → Devices & Services → MQTT** should show both devices populated.
+
+---
+
+## Per-appliance notes
+
+### Dryer
+
+| Capability | Works? | Notes |
+|---|---|---|
+| Read all state | ✅ | Machine state, job state, energy (W + kWh), course, dry level, completion time, remote control, child lock, alarms |
+| Wrinkle Prevent toggle | ✅ | Persists |
+| Start / Pause / Stop | ✅ | Via `/operational/state/vs/0`; needs Remote Control on |
+| Change course | ✅ | Via `/st/dryercourse/vs/0`; needs Remote Control on. **Not exposed by the SmartThings cloud HA integration.** |
+| Power on/off | ❌ | Accepted (2.04) but reverts within seconds; hardware-mirrored |
+| Child Lock / Remote Control toggle | ❌ | Same; hardware-mirrored physical buttons |
+
+The dryer's `/operational/state/vs/0` is on the bridge's hot poll tier (1s idle / 0.5s while a cycle is active) and also accepts OBSERVE registration. When the appliance has internet it pushes notifications within ~100ms of any state change and the cache absorbs them as fast freshness; when air-gapped the hot-tier poll carries the same UX with worst-case lag of one tier interval.
+
+### Oven
+
+| Capability | Works? | Notes |
+|---|---|---|
+| Read state | ✅ | Cavity state, current/target temp, door, mode, alarms, firmware-update-available |
+| Lamp (light entity) | ✅ | Binary On/Off only; High/Low/Dim values are accepted (2.04) but silently coerced back. Works regardless of Remote Control. |
+| Sound, Fast preheat | ⚠️ | Wired but untested RC-gated. |
+| Setpoint slider | ⚠️ | Wired but untested RC-gated. |
+| Mode select | ⚠️ | Wired but untested RC-gated. |
+| Stop button | ✅ |  |
+| **Kitchen timer (`⏲` icon)** | ❌ | **The oven's panel kitchen timer is not exposed via CoAP at all.** Confirmed by full `/device/0` dump: `UpperTimer*` fields in `/mode/vs/0` only populate when set via the API, not from the panel. |
+
+**The oven doesn't push OBSERVE on `/mode/vs/0` writes** (the dryer does). The bridge handles this transparently because state freshness comes from polling rather than from OBSERVE:
+1. **Optimistic publish** — the moment a POST returns 2.04, the bridge merges the write body into the cache and publishes to MQTT. HA reflects the new value instantly.
+2. **Scheduler reconciliation** — the PollScheduler defers polling the just-written resource for ~4s (past Samsung's fetchback-revert window), then refreshes it on its tier cadence. If the device silently coerced the value, the corrected state is republished and HA reverts.
+3. **Periodic `/device/0` sweep** — every 5 minutes the scheduler's sweep tier re-fetches the whole device tree, bounding worst-case drift on any resource the per-tier polls don't cover.
+
+### Fridge (ARTIK051)
+
+Contributed by [@aminorjourney](https://github.com/aminorjourney) in PR #1, verified against an `ARTIK051_REF_17K` fridge-freezer on firmware `DA-REF-ART-COMMON-1_20201124`. First public documentation of this firmware's local resource layout.
+
+| Capability | Works? | Notes |
+|---|---|---|
+| Read temperatures | ✅ | Fridge + freezer current + setpoint via `/temperatures/vs/0` |
+| Read doors | ✅ | Fridge, freezer, convertible zone via `/doors/vs/0` items array; plus an "any door open" binary sensor |
+| Energy monitoring | ✅ | Instantaneous W + cumulative Wh via `/energy/consumption/vs/0` |
+| Water filter | ✅ | Usage % + status via `/filter/waterfilter/vs/0` |
+| Ice maker | ✅ | State + ice-making status via `/icemaker/one/vs/0` |
+| Setpoint slider (fridge / freezer) | ✅ | Fridge 1–7°C, freezer -23 to -15°C |
+| Power Cool, Power Freeze, Sabbath, Ice Maker switches | ✅ | |
+| Active modes | ✅ | Read-only sensor of the fridge's mode list |
+
+Notes specific to this firmware family:
+- **Port 49155**, not the 49154 the oven defaults to.
+- `/oic/res` only advertises 15 paths; the full resource tree lives at `/device/0` (32 links). The bridge's periodic `/device/0` sweep handles this transparently; no descriptor change needed.
+- `/hass/state/vs/0` and `/hass/command/vs/0` return `4.04`. They're vestigial paths from an earlier firmware and are ignored.
+- Doors are exposed as a Samsung-plural collection resource (`/doors/vs/0` with an `items[]` array keyed by `x.com.samsung.da.description`), not as per-room OCF resources like the newer RF9000B-class fridges use. This is one of the concrete divergences behind the ["Firmware families" caveat](https://github.com/QuiteYellow/SmartThings-Local/blob/main/README.md#firmware-families-a-limitation) in the README.
+
+---
+
+## Reference
+
+### Config keys
+
+| Key | Meaning |
+|---|---|
+| `APPLIANCE_COUNT` | Number of `APPLIANCE_<n>_*` blocks to read (1-indexed) |
+| `APPLIANCE_<n>_CLASS` | Descriptor name: `dryer`, `oven`, `fridge` |
+| `APPLIANCE_<n>_IP` | LAN IP of the appliance |
+| `APPLIANCE_<n>_OCF_PORT` | Optional. Blank → probe standard port 5684 and the dynamic range 49152–49160 with a stateless ClientHello; set it to pin and gate one specific port (dryer=49155, oven=49154, fridge=49155) |
+| `APPLIANCE_<n>_TOPIC` | MQTT topic prefix (also the HA device identifier; changing it re-keys the device) |
+| `APPLIANCE_<n>_NAME` | Friendly name on the HA device card |
+| `MQTT_BROKER` / `MQTT_PORT` / `MQTT_USER` / `MQTT_PASS` | Broker config |
+| `HA_DISCOVERY_PREFIX` | HA discovery topic root (default `homeassistant`) |
+| `CERT_PATH` / `KEY_PATH` | Override cert lookup (auto-detects `/config/` then `./certs/`) |
+| `HEALTH_INTERVAL_S` | Seconds between `<prefix>/bridge/health` publishes (default 60) |
+| `PING_INTERVAL_S` | CoAP empty-CON ping cadence; three consecutive failures publish `availability=offline` (default 25). Tier polling cadences are descriptor-declared, not env-tunable. |
+| `CLOCK_SYNC_INTERVAL_H` | Hours between appliance clock writes, for descriptors that declare one (default 24; `0` disables the sync and its button) |
+| `SSH_HOST` / `REMOTE_DIR` / `APPDATA_DIR` | Used by `deploy.sh` only |
+
+### MQTT topics — outgoing (bridge → broker)
+
+Per appliance, where `<prefix>` is its `APPLIANCE_<n>_TOPIC`.
+
+| Topic | Retain | When |
+|---|---|---|
+| `<prefix>/availability` | ✓ | `online` after seed; `offline` on disconnect (LWT for appliance #1) |
+| `<prefix>/remote_available` | ✓ | `online` iff bridge is up AND Remote Control on the appliance is on. Gates the control entities. |
+| `<prefix>/state` | ✓ | JSON sensor dict; published only when sensors actually diff |
+| `<prefix>/bridge/health` | ✓ | Every `HEALTH_INTERVAL_S`: connect_count, error_count, notif_count, poll_count, poll_error_count, ping_count, ping_fail_count, reachable, last_change_age_s, last_seed_age_s, session_age_s, stalest_href, stalest_age_s, serial |
+| `<ha_prefix>/{sensor,binary_sensor,switch,light,number,select,button}/<prefix>/.../config` | ✓ | HA MQTT discovery, republished on every MQTT (re)connect |
+
+### MQTT topics — incoming (bridge subscribes)
+
+`<prefix>/cmd/#`. **The MQTT user must have READ permission on this subtree.** Without it the broker silently drops the TCP connection shortly after SUBSCRIBE. Check broker logs if writes never land.
+
+Dryer:
+
+| Suffix | Payloads | Effect |
+|---|---|---|
+| `cmd/wrinkle_prevent` | `On`, `Off` | POST `/washer/vs/0` |
+| `cmd/operational_state` | `Run`, `Pause`, `Ready` | POST `/operational/state/vs/0`; requires RC |
+| `cmd/dryer_mode` | Course name (e.g. `Cotton`) | Translated to `Course_HH` then POST `/st/dryercourse/vs/0`; requires RC |
+
+Oven:
+
+| Suffix | Payloads | Effect |
+|---|---|---|
+| `cmd/lamp` | `On`, `Off` | RMW of `/mode/vs/0 .options[UpperLamp_*]` |
+| `cmd/sound` | `On`, `Off` | RMW of `/mode/vs/0 .options[Sound_*]` |
+| `cmd/fastpreheat` | `On`, `Off` | RMW of `/mode/vs/0 .options[fastpreheat_*]` |
+| `cmd/setpoint` | Integer °C (30–270, step 5) | RMW of `/temperatures/vs/0 .items[0].desired`; requires RC |
+| `cmd/mode` | Mode name (e.g. `Convection`, `LargeGrill`) | POST `/mode/vs/0 {modes: [<name>]}`; requires RC |
+| `cmd/stop` | (button press) | POST `/operational/state/vs/0 {state: Ready}` |
+| `cmd/sync_clock` | (button press) | POST `/configuration/vs/0 {x.com.samsung.da.currentTime: <host local time>}` |
+
+#### Clock sync
+
+An appliance kept off the internet has no way to correct its own clock, so the display drifts. Where a descriptor declares a `ClockSync` spec (today the oven), the bridge writes the host's local wall clock to `/configuration/vs/0` as `x.com.samsung.da.currentTime` every `CLOCK_SYNC_INTERVAL_H` hours, and exposes a Sync clock button for an immediate write. Set `CLOCK_SYNC_INTERVAL_H=0` to switch off both.
+
+The field is write-only: a GET of that resource returns the metadata without it, so the value never enters the state cache and no sensor reports it. Timestamps land in the container's `TZ`.
+
+The write came from LocalThings [#404](https://github.com/mbillow/localthings/issues/404) / [#428](https://github.com/mbillow/localthings/pull/428), verified there on a TP1X range and originally documented on [the SmartThings forum](https://community.smartthings.com/t/samsung-oven-range-and-cooktop-sync-time-api/251391). Both the periodic write and the button answer 2.04 on the oven this repo's sample descriptor targets. Other appliance classes are untested — a rejection shows up as a 4.xx in the bridge log, and nothing else is written to the resource.
+
+One limit is worth knowing whatever the appliance. A timestamp far outside its certificate validity window can break certificate verification and leave it unresponsive, so the bridge refuses to write a host clock reading outside `PLAUSIBLE_FROM`/`PLAUSIBLE_UNTIL` in `mqtt_demo/clock_sync.py`. A host that boots without NTP skips the sync rather than writing 1970.
+
+### Entity counts (approximate, per appliance)
+
+| Type | Dryer | Oven |
+|---|---|---|
+| `sensor` | 17 | 17 |
+| `binary_sensor` | 4 | 7 |
+| `switch` | 1 (wrinkle) | 2 (sound, fastpreheat) |
+| `light` | — | 1 (lamp) |
+| `number` | — | 1 (setpoint slider) |
+| `select` | 1 (course) | 1 (mode) |
+| `button` | 3 (start/pause/stop) | 2 (stop, sync clock) |
+
+Gated control entities use HA's `availability_mode: all` against `<prefix>/availability` AND `<prefix>/remote_available`. Flip Remote Control on the appliance's front panel and those entities un-grey in HA.\n

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -506,3 +506,34 @@ def test_readme_links_render_on_pypi_and_on_github():
         if target.startswith(_REPO_BLOB):
             path = _REPO_ROOT / target[len(_REPO_BLOB):].split("#", 1)[0]
             assert path.exists(), f"README links to a missing file: {target}"
+
+
+def test_links_between_markdown_files_resolve():
+    """A cross-file anchor breaks silently: GitHub serves the page and does
+    not scroll, so a renamed heading leaves no trace.
+
+    `docs/bridge-demo.md` points into the README, which is the dependency
+    the bridge extraction created, and the README points back at the docs.
+    """
+    documents = [_REPO_ROOT / "README.md", *sorted((_REPO_ROOT / "docs").glob("*.md"))]
+    headings = {
+        document.name: {
+            generate_api_docs._slug(line)
+            for line in document.read_text().splitlines()
+            if line.startswith("#")
+        }
+        for document in documents
+    }
+
+    for document in documents:
+        for target in re.findall(r"\]\(([^)]+)\)", document.read_text()):
+            if not target.startswith(_REPO_BLOB):
+                continue
+            path, _, anchor = target[len(_REPO_BLOB):].partition("#")
+            assert (_REPO_ROOT / path).exists(), f"{document.name} -> {target}"
+            if anchor:
+                known = headings.get(Path(path).name)
+                assert known is not None, f"{document.name} -> {target}"
+                assert anchor in known, (
+                    f"{document.name} links to a heading that is gone: {target}"
+                )


### PR DESCRIPTION

First of the README split. The file was 1188 lines serving a library consumer, an appliance owner, a bridge deployer and a contributor at once, and `pyproject` sets `readme = "README.md"`, so a `pip install smartthings-local` reader also got Unraid deployment steps.

`docs/bridge-demo.md` takes the bridge material: what it exposes, how it is configured and deployed, per-appliance coverage, config keys, MQTT topics, entity counts. 245 lines moved, README down to 944.

## Two of those sections were in the wrong parent

"What the demo bridge gives you" and "Under the hood" were `h3` children of "BLE OCF framing", so a codec section owned the bridge's architecture. That was the real reason the material was hard to find.

## The judgement calls

- *Per-appliance notes* went with the bridge. The capability tables are written around the bridge's poll tiers and entity behaviour, so they read as bridge coverage. A library consumer wanting the same protocol facts has "Traps to avoid" and the API reference.
- *Repo layout* stayed, promoted to `h2`. It orients anyone in the repo, including the library tree, and its `## Reference` parent left with the bridge config.
- *Traps to avoid* stayed. OBSERVE path selection, leaving `/oic/sec/*` alone, one session per peer: those are protocol lessons that outlive the demo.
- *Parts 1 to 4* stopped being a sequence once 3 and 4 moved, so the numbering is gone from all four, and the three prose references to "Part 1" and "Part 2" now name their sections.
- The four library sections that were *also* `h3` children of "BLE OCF framing" are reparented under a new *Library reference* `h2`.

## A guard for the dependency this created

`docs/bridge-demo.md` now links back into the README, and the README links out to the docs. A cross-file anchor breaks silently: GitHub serves the page and does not scroll, so a renamed heading leaves no trace. A test walks the links between the README and every file in `docs/`, checks the target file exists, and checks the anchor matches a heading there. Confirmed by renaming a target heading and watching it fail.

## What this did not fix

"BLE OCF framing" still owns 234 lines covering three library topics under one heading: the codec, the authentication providers (`CertificateAuth`, `PskAuth`, `validate_identity`) and OwnerPSK derivation. Authentication is the one thing every consumer needs, and it has only prose to find it by, which leaves it unlinkable and absent from the sidebar. Sorting that out is the library-reference pass, and its own change.

## Validation

798 tests pass on Python 3.11, 3.12, 3.13 and 3.14, and on the dependency floor. `check_share_safety.py` is clean. Line accounting checks out: 245 lines left the README, and the new file is 258 including its own 13-line header.
